### PR TITLE
Add Imagine Bundle Recipe

### DIFF
--- a/liip/imagine-bundle/1.8/etc/packages/imagine.yaml
+++ b/liip/imagine-bundle/1.8/etc/packages/imagine.yaml
@@ -1,0 +1,36 @@
+#liip_imagine:
+#    
+#    # valid drivers options include "gd" or "gmagick" or "imagick"
+#    driver: "gd"
+#
+#    # define your filter sets under this option
+#    filter_sets:
+#
+#        # an example thumbnail transformation definition
+#        # https://symfony.com/doc/current/bundles/LiipImagineBundle/basic-usage.html#create-thumbnails
+#        squared_thumbnail:
+#
+#            # set your image quality defaults
+#            jpeg_quality:          85
+#            png_compression_level: 8
+#            
+#            # setup the filter steps to apply for this transformation
+#            filters:
+#
+#                # auto rotate the image using EXIF metadata
+#                auto_rotate: ~
+#
+#                # strip the image of all metadata
+#                strip: ~
+#
+#                # scale and square the image to the given dimensions
+#                thumbnail:
+#                    size:          [253, 253]
+#                    mode:          outbound
+#                    allow_upscale: true
+#
+#                # create border by placing image on larger black background
+#                background:
+#                    size:     [256, 256]
+#                    position: center
+#                    color:    '#fff'

--- a/liip/imagine-bundle/1.8/etc/routing/imagine.yaml
+++ b/liip/imagine-bundle/1.8/etc/routing/imagine.yaml
@@ -1,0 +1,2 @@
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.yaml"

--- a/liip/imagine-bundle/1.8/manifest.json
+++ b/liip/imagine-bundle/1.8/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Liip\\ImagineBundle\\LiipImagineBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    }
+}

--- a/liip/imagine-bundle/1.8/post-install.txt
+++ b/liip/imagine-bundle/1.8/post-install.txt
@@ -1,0 +1,6 @@
+  <bg=blue;fg=white>         Getting started using </><bg=blue;fg=white;options=bold>liip/imagine-bundle</><bg=blue;fg=white>          </>
+
+  <fg=blue;options=bold>Configure</> <fg=blue>your transformations:</>
+    1. You <options=bold>MUST</> verify and uncomment the configuration in <comment>%ETC_DIR%/packages/imagine.yaml</>.
+    2. You <options=bold>MAY</> configure your image transformation library (<comment>gmagick</>, <comment>imagick</>, or <comment>gd</> [default]).
+    3. You <options=bold>MAY</> define custom transformation definitions under the <comment>filter_sets</> option.


### PR DESCRIPTION
This pull request adds a Symfony Flex recipe for [`LiipImagineBundle`](https://github.com/liip/LiipImagineBundle), a popular image manipulation bundle that leverages the [Imagine Library](https://github.com/avalanche123/Imagine) internally.

I am waiting for some reviews from my fellow bundle maintainers, so do not merge this immediately. Also, as there isn't much information or many examples on writing these recipes yet, I look forward to fielding reviews or change requests from this repository's maintainers, as well.

Hopefully, this bundle will land in the exciting Symfony Flex ecosystem shortly!