### PR TITLE
Added ExerciseHTMLPurifierBundle

### DIFF
--- a/exercise/htmlpurifier-bundle/0.2/etc/packages/exercise_html_purifier.yaml
+++ b/exercise/htmlpurifier-bundle/0.2/etc/packages/exercise_html_purifier.yaml
@@ -1,0 +1,5 @@
+exercise_html_purifier:
+    # full configuration reference: http://htmlpurifier.org/live/configdoc/plain.html
+    default:
+        # the charset used by the original contents
+        Core.Encoding: 'UTF-8'

--- a/exercise/htmlpurifier-bundle/0.2/manifest.json
+++ b/exercise/htmlpurifier-bundle/0.2/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Exercise\\HTMLPurifierBundle\\ExerciseHTMLPurifierBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    }
+}


### PR DESCRIPTION
About the bundle:

* 600,000 downloads
* https://packagist.org/packages/exercise/htmlpurifier-bundle

---

I've added the `Core.Encoding` option in the default config to make it easier to chage because I guess this could be useful for legacy systems still using `ISO-8859-1` or for our Asian friends who still not use UTF-8. But this is just a guess, so I could be totally wrong.

License MIT