### PR TITLE
(WIP) Added WebuniCommonMarkBundle

### DIFF
--- a/webuni/commonmark-bundle/0.2/etc/packages/webuni_commonmark.yaml
+++ b/webuni/commonmark-bundle/0.2/etc/packages/webuni_commonmark.yaml
@@ -1,0 +1,6 @@
+webuni_commonmark:
+    extensions:
+        # adds support for defining attributes on HTML elements (e.g. 'id', 'class', 'style')
+        attributes: true
+        # adds support for parsing Markdown tables
+        table: true

--- a/webuni/commonmark-bundle/0.2/manifest.json
+++ b/webuni/commonmark-bundle/0.2/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Webuni\\Bundle\\CommonMarkBundle\\WebuniCommonMarkBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    }
+}


### PR DESCRIPTION
About the bundle:

* https://github.com/webuni/commonmark-bundle

---

Although the bundle is still tiny in number of downloads, it integrates the popular CommonMark PHP library (https://github.com/thephpleague/commonmark) which is the reference implementation of Markdown in PHP and other popular (and great!) extensions (https://github.com/webuni/commonmark-attributes-extension and https://github.com/webuni/commonmark-table-extension).

@hason as the author of the bundle and the extensions, could you please review this recipe? Thanks!