### PR TITLE
Added AlgoliaAlgoliaSearchBundle

### DIFF
--- a/algolia/algolia-search-bundle/2.2/etc/packages/algolia.yaml
+++ b/algolia/algolia-search-bundle/2.2/etc/packages/algolia.yaml
@@ -1,0 +1,3 @@
+algolia:
+    application_id: "%env(ALGOLIA_APP_ID)%"
+    api_key: "%env(ALGOLIA_API_KEY)%"

--- a/algolia/algolia-search-bundle/2.2/manifest.json
+++ b/algolia/algolia-search-bundle/2.2/manifest.json
@@ -6,7 +6,7 @@
         "etc/": "%ETC_DIR%/"
     },
     "env": {
-        "ALGOLIA_APP_ID": "AAAAAAAAAA",
-        "ALGOLIA_API_KEY": "00000000000000000000000000000000"
+        "ALGOLIA_APP_ID": "...",
+        "ALGOLIA_API_KEY": "..."
     }
 }

--- a/algolia/algolia-search-bundle/2.2/manifest.json
+++ b/algolia/algolia-search-bundle/2.2/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Algolia\\AlgoliaSearchBundle\\AlgoliaAlgoliaSearchBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    },
+    "env": {
+        "ALGOLIA_APP_ID": "AAAAAAAAAA",
+        "ALGOLIA_API_KEY": "00000000000000000000000000000000"
+    }
+}


### PR DESCRIPTION
About the bundle:

* ~70,000 downloads
* It integrates the amazing Algolia search service (we use it on symfony.com for example)
* https://github.com/algolia/AlgoliaSearchBundle

---

I have a question about the env vars. As you can see, in the default config I've used "realistic values" for the APP_ID and API_KEY (the placeholders are similar to the real values that you'll put there). Do you like that ... or do you prefer to put some generic placeholder? Example:

```json
"env": {
    "ALGOLIA_APP_ID": "you app ID",
    "ALGOLIA_API_KEY": "your API key"
}
```

License MIT
