### PR TITLE
(WIP) Added MisdPhoneNumberBundle

### DIFF
--- a/misd/phone-number-bundle/1.2/etc/packages/libphonenumber.yaml
+++ b/misd/phone-number-bundle/1.2/etc/packages/libphonenumber.yaml
@@ -1,0 +1,4 @@
+doctrine:
+    dbal:
+        types:
+            phone_number: Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType

--- a/misd/phone-number-bundle/1.2/manifest.json
+++ b/misd/phone-number-bundle/1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Misd\\PhoneNumberBundle\\MisdPhoneNumberBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    }
+}


### PR DESCRIPTION
About this bundle:

* ~700,000 downloads
* https://github.com/misd-service-development/phone-number-bundle

---

**My question**: which is the right way to register the PhoneNumberType DBAL type dynamically?

I guess the provided `libphonenumber.yaml` is wrong and we'd need some PHP file that detectes if Doctrine exists and then registers the type. Can anyone help me doing that? Thanks!