### PR TITLE
Add recipe for Wisembly AMQP bundle

### DIFF
--- a/wisembly/amqp-bundle/1.3/config/packages/wisembly_amqp.yaml
+++ b/wisembly/amqp-bundle/1.3/config/packages/wisembly_amqp.yaml
@@ -1,0 +1,16 @@
+wisembly_amqp:
+    console_path: '%kernel.project_dir%/bin/console'
+    broker: 'oldsound'
+    connections:
+        default: '%env(AMQP_URL)%'
+    gates:
+        # here you should declare all your "gates", which are the cornerstone
+        # of this amqp bundle.
+        #
+        # For each gates declares which queue and which exchange it should
+        # communicate with, if these should be auto_declared, which connection
+        # it should use, ... and so on.
+        acme:
+            auto_declare: true
+            queue: acme_queue
+            exchange: acme_exchange

--- a/wisembly/amqp-bundle/1.3/manifest.json
+++ b/wisembly/amqp-bundle/1.3/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Wisembly\\AmqpBundle\\WisemblyAmqpBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "AMQP_URL": "amqp://guest:guest@localhost:5672"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Integration for Wisembly's AMQP bundle, which offers a slightly different (well not so different now...) than the SwarrotBundle. Works with Swarrot.
