### PR TITLE
(WIP) Added SentryBundle

### DIFF
--- a/sentry/sentry-symfony/0.7/etc/packages/prod/sentry.yaml
+++ b/sentry/sentry-symfony/0.7/etc/packages/prod/sentry.yaml
@@ -1,0 +1,3 @@
+sentry:
+    dsn: "%env(SENTRY_DSN)%"
+    release: "%env(APP_RELEASE)%"

--- a/sentry/sentry-symfony/0.7/manifest.json
+++ b/sentry/sentry-symfony/0.7/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "Sentry\\SentryBundle\\SentryBundle": ["prod"]
+    },
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    },
+    "env": {
+        "#1": "Get the Sentry DSN of your project on https://docs.sentry.io/quickstart/#about-the-dsn",
+        "SENTRY_DSN": "https://PUBLIC_KEY:SECRET_KEY@HOST/PATH/PROJECT_ID",
+        "APP_RELEASE": "dev"
+    }
+}


### PR DESCRIPTION
References:
* https://sentry.io/for/symfony/
* https://docs.sentry.io/clients/php/integrations/symfony2/

This bundle is not required to get error reported to Sentry. The Symfony logger has a listener on uncaught exceptions and Monolog has the `RavenHandler` that send messages to Sentry.

---

I have a question regarding the "release" config. This is more related to the version of the code that an environment variable. 

| Q             | A
| ------------- | ---
| License       | MIT