### PR TITLE
Enqueue packages

### DIFF
--- a/enqueue/async-event-dispatcher/0.7/config/packages/enqueue_async_event_dispatcher.yaml
+++ b/enqueue/async-event-dispatcher/0.7/config/packages/enqueue_async_event_dispatcher.yaml
@@ -1,0 +1,5 @@
+enqueue:
+    async_events:
+        enabled: true
+        # if you'd like to send send messages onTerminate use spool_producer (it makes response time even lesser):
+        # spool_producer: true

--- a/enqueue/async-event-dispatcher/0.7/manifest.json
+++ b/enqueue/async-event-dispatcher/0.7/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/enqueue/pheanstalk/0.5/manifest.json
+++ b/enqueue/pheanstalk/0.5/manifest.json
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "ENQUEUE_DSN": "beanstalk://"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

contains https://github.com/symfony/recipes-contrib/pull/59.

Contains recipes for enqueue packages:

* enqueue/amqp-bunny
* enqueue/amqp-lib
* enqueue/async-event-dispatcher
* enqueue/gearman
* enqueue/gps (Google PubSub)
* enqueue/sqs (Amazon SQS)
* enqueue/stomp
* enqueue/redis

