### PR TITLE
Fix bundle namespace in BazingaGeocoderBundle 4.1

### DIFF
--- a/willdurand/geocoder-bundle/4.1/manifest.json
+++ b/willdurand/geocoder-bundle/4.1/manifest.json
@@ -1,6 +1,6 @@
 {
     "bundles": {
-        "Bazinga\\GeocoderBundle\\BazingaGeocoderBundle": ["all"]
+        "Bazinga\\Bundle\\GeocoderBundle\\BazingaGeocoderBundle": ["all"]
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

See https://github.com/geocoder-php/BazingaGeocoderBundle/blob/4.1.0/BazingaGeocoderBundle.php
