### PR TITLE
Add MsgPhp User bundle

### DIFF
--- a/msgphp/user-bundle/0.1/config/packages/doctrine.yaml.dist
+++ b/msgphp/user-bundle/0.1/config/packages/doctrine.yaml.dist
@@ -1,0 +1,16 @@
+doctrine:
+    dbal:
+        url: '%env(DATABASE_URL)%'
+        charset: utf8mb4
+        default_table_options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
+
+    orm:
+        auto_generate_proxy_classes: '%kernel.debug%'
+        naming_strategy: doctrine.orm.naming_strategy.underscore
+        mappings:
+            app:
+                dir: '%kernel.project_dir%/src/Entity'
+                type: annotation
+                prefix: App\Entity

--- a/msgphp/user-bundle/0.1/config/packages/msgphp_doctrine.php
+++ b/msgphp/user-bundle/0.1/config/packages/msgphp_doctrine.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Entity\Eav\Attribute;
+use App\Entity\User\User;
+use MsgPhp\Eav\Entity\Attribute as BaseAttribute;
+use MsgPhp\Eav\Infra\Doctrine\Type\{AttributeIdType, AttributeValueIdType};
+use MsgPhp\User\Entity\User as BaseUser;
+use MsgPhp\User\Infra\Doctrine\Type\UserIdType;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return function (ContainerConfigurator $container) {
+    $container->extension('doctrine', [
+        'dbal' => [
+            'types' => [
+                AttributeIdType::NAME => AttributeIdType::class,
+                AttributeValueIdType::NAME => AttributeValueIdType::class,
+                UserIdType::NAME => UserIdType::class,
+            ],
+        ],
+        'orm' => [
+            'resolve_target_entities' => [
+                BaseAttribute::class => Attribute::class,
+                BaseUser::class => User::class,
+            ],
+            'mappings' => [
+                'msgphp_attribute' => [
+                    'dir' => '%kernel.project_dir%/vendor/msgphp/eav/Infra/Doctrine/Resources/mapping',
+                    'type' => 'xml',
+                    'prefix' => 'MsgPhp\Eav\Entity',
+                    'is_bundle' => false,
+                ],
+                'msgphp_user' => [
+                    'dir' => '%kernel.project_dir%/vendor/msgphp/user/Infra/Doctrine/Resources/mapping',
+                    'type' => 'xml',
+                    'prefix' => 'MsgPhp\User\Entity',
+                    'is_bundle' => false,
+                ],
+            ],
+        ],
+    ]);
+};

--- a/msgphp/user-bundle/0.1/config/packages/msgphp_user.php
+++ b/msgphp/user-bundle/0.1/config/packages/msgphp_user.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Entity\User\{PendingUser, User, UserAttributeValue, UserRole, UserSecondaryEmail};
+use App\Security\UserRoleProvider;
+use MsgPhp\User\Infra\Security\UserRoleProviderInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return function (ContainerConfigurator $container) {
+    $container->extension('msgphp_user', [
+        'pending_user_class' => PendingUser::class,
+        'user_attribute_value_class' => UserAttributeValue::class,
+        'user_class' => User::class,
+        'user_role_class' => UserRole::class,
+        'user_secondary_email_class' => UserSecondaryEmail::class,
+    ]);
+
+    $container->services()
+        ->defaults()
+            ->autowire()
+            ->private()
+        ->set(UserRoleProvider::class)
+        ->alias(UserRoleProviderInterface::class, UserRoleProvider::class)
+    ;
+};

--- a/msgphp/user-bundle/0.1/config/packages/msgphp_user_events.php
+++ b/msgphp/user-bundle/0.1/config/packages/msgphp_user_events.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\EventSubscriber\{SendAccountConfirmationUrlToPendingUser, SendEmailConfirmationUrlToUser, SendPasswordResetUrlToUser};
+use MsgPhp\User\Event\{PendingUserCreatedEvent, UserPasswordRequestedEvent, UserPendingPrimaryEmailSetEvent, UserSecondaryEmailAddedEvent};
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return function (ContainerConfigurator $container) {
+    $container->services()
+        ->defaults()
+            ->autowire()
+            ->public()
+        ->set(SendAccountConfirmationUrlToPendingUser::class)
+            ->tag('event_subscriber', ['subscribes_to' => PendingUserCreatedEvent::class])
+        ->set(SendEmailConfirmationUrlToUser::class)
+            ->tag('event_subscriber', ['subscribes_to' => UserSecondaryEmailAddedEvent::class])
+            ->tag('event_subscriber', ['subscribes_to' => UserPendingPrimaryEmailSetEvent::class])
+        ->set(SendPasswordResetUrlToUser::class)
+            ->tag('event_subscriber', ['subscribes_to' => UserPasswordRequestedEvent::class])
+    ;
+};

--- a/msgphp/user-bundle/0.1/config/packages/security.yaml.dist
+++ b/msgphp/user-bundle/0.1/config/packages/security.yaml.dist
@@ -1,0 +1,29 @@
+security:
+    encoders:
+        MsgPhp\User\Infra\Security\SecurityUser: bcrypt
+
+    providers:
+         msgphp_user: { id: MsgPhp\User\Infra\Security\SecurityUserProvider }
+
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            provider: msgphp_user
+            user_checker: MsgPhp\User\Infra\Security\SecurityUserChecker
+            anonymous: ~
+            form_login:
+                login_path: login
+                check_path: login
+                default_target_path: index
+                username_parameter: email
+                password_parameter: password
+                remember_me: true
+            remember_me:
+                secret: '%kernel.secret%'
+                remember_me_parameter: remember_me
+            logout:
+                path: logout
+            switch_user: true
+            logout_on_user_change: true

--- a/msgphp/user-bundle/0.1/config/routes/msgphp_user.php
+++ b/msgphp/user-bundle/0.1/config/routes/msgphp_user.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Controller\User\{ConfirmAccountController, ConfirmEmailController, ForgotPasswordController, LoginController, MyAccountController, RegisterController, ResetPasswordController};
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->add('login', '/login')
+            ->controller(LoginController::class)
+        ->add('logout', '/logout')
+        ->add('register', '/register')
+            ->controller(RegisterController::class)
+        ->add('confirm_account', '/confirm-account/{token}')
+            ->controller(ConfirmAccountController::class)
+        ->add('confirm_email', '/confirm-email/{token}')
+            ->controller(ConfirmEmailController::class)
+        ->add('forgot_password', '/forgot-password')
+            ->controller(ForgotPasswordController::class)
+        ->add('reset_password', '/reset-password/{token}')
+            ->controller(ResetPasswordController::class)
+        ->add('my_account', '/my-accounts')
+            ->controller(MyAccountController::class)
+    ;
+};

--- a/msgphp/user-bundle/0.1/manifest.json
+++ b/msgphp/user-bundle/0.1/manifest.json
@@ -1,0 +1,10 @@
+{
+    "bundles": {
+        "MsgPhp\\UserBundle\\MsgPhpUserBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/",
+        "templates/": "templates/"
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/ConfirmAccountController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/ConfirmAccountController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Entity\User\PendingUser;
+use MsgPhp\Domain\CommandBusInterface;
+use MsgPhp\User\Command\ConfirmPendingUserCommand;
+use MsgPhp\User\Infra\Uuid\UserId;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class ConfirmAccountController
+{
+    /**
+     * @ParamConverter("pendingUser", options={"mapping": {"token": "token"}})
+     */
+    public function __invoke(
+        PendingUser $pendingUser,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator,
+        CommandBusInterface $commandBus
+    ): Response
+    {
+        $commandBus->handle(new ConfirmPendingUserCommand($pendingUser->getToken(), new UserId()));
+        $flashBag->add('success', sprintf('Hi, your account is confirmed. You can now login.'));
+
+        return new RedirectResponse($urlGenerator->generate('login'));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/ConfirmEmailController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/ConfirmEmailController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Entity\User\UserSecondaryEmail;
+use MsgPhp\Domain\CommandBusInterface;
+use MsgPhp\User\Command\ConfirmUserSecondaryEmailCommand;
+use MsgPhp\User\Infra\Security\SecurityUserFactory;
+use MsgPhp\User\Repository\UserSecondaryEmailRepositoryInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class ConfirmEmailController
+{
+    /**
+     * @ParamConverter("userSecondaryEmail", options={"mapping": {"token": "token"}})
+     */
+    public function __invoke(
+        UserSecondaryEmail $userSecondaryEmail,
+        SecurityUserFactory $securityUserFactory,
+        TokenStorageInterface $tokenStorage,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator,
+        CommandBusInterface $commandBus,
+        UserSecondaryEmailRepositoryInterface $userSecondaryEmailRepository
+    ): Response
+    {
+        if (!$userSecondaryEmail->getUserId()->equals($securityUserFactory->getUserId())) {
+            throw new NotFoundHttpException();
+        }
+
+        $wasPendingPrimary = $userSecondaryEmail->isPendingPrimary();
+
+        $commandBus->handle(new ConfirmUserSecondaryEmailCommand($userSecondaryEmail->getToken()));
+
+        if ($wasPendingPrimary) {
+            $flashBag->add('success', sprintf('Hi, your e-mail is confirmed. Please login again.'));
+            $tokenStorage->setToken(null);
+
+            return new RedirectResponse($urlGenerator->generate('login'));
+        }
+
+        $flashBag->add('success', 'Hi, your e-mail is confirmed.');
+
+        return new RedirectResponse($urlGenerator->generate('my_account'));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/ForgotPasswordController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/ForgotPasswordController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Form\User\ForgotPasswordType;
+use MsgPhp\Domain\CommandBusInterface;
+use MsgPhp\User\Command\RequestUserPasswordCommand;
+use MsgPhp\User\Infra\Security\SecurityUserFactory;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+final class ForgotPasswordController
+{
+    public function __invoke(
+        SecurityUserFactory $securityUser,
+        Request $request,
+        FormFactoryInterface $formFactory,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator,
+        Environment $twig,
+        CommandBusInterface $commandBus
+    ): Response
+    {
+        if ($securityUser->isAuthenticated()) {
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        $form = $formFactory->createNamed('', ForgotPasswordType::class);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+
+            $commandBus->handle(new RequestUserPasswordCommand($data['email']));
+            $flashBag->add('success', sprintf('Hi %s, we\'ve send you a reset link.', $data['email']));
+
+            return new RedirectResponse($urlGenerator->generate('index'));
+        }
+
+        return new Response($twig->render('User/forgot_password.html.twig', [
+            'form' => $form->createView(),
+        ]));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/LoginController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/LoginController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Form\User\LoginType;
+use MsgPhp\User\Infra\Security\SecurityUserFactory;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Twig\Environment;
+
+final class LoginController
+{
+    public function __invoke(
+        SecurityUserFactory $securityUser,
+        Environment $twig,
+        FormFactoryInterface $formFactory,
+        UrlGeneratorInterface $urlGenerator,
+        AuthenticationUtils $authenticationUtils
+    ): Response
+    {
+        if ($securityUser->isAuthenticated()) {
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        $form = $formFactory->createNamed('', LoginType::class, [
+            'email' => $authenticationUtils->getLastUsername(),
+        ]);
+
+        if (null !== $error = $authenticationUtils->getLastAuthenticationError(true)) {
+            $form->addError(new FormError($error->getMessage(), $error->getMessageKey(), $error->getMessageData()));
+        }
+
+        return new Response($twig->render('User/login.html.twig', [
+            'form' => $form->createView(),
+        ]));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/MyAccountController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/MyAccountController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\EventSubscriber\SendEmailConfirmationUrlToUser;
+use App\Form\User\AddSecondaryEmailType;
+use App\Form\User\ChangeEmailType;
+use App\Form\User\ChangePasswordType;
+use App\Security\PasswordConfirmation;
+use MsgPhp\Domain\CommandBusInterface;
+use MsgPhp\User\Command\AddUserSecondaryEmailCommand;
+use MsgPhp\User\Command\ChangeUserPasswordCommand;
+use MsgPhp\User\Command\DeleteUserSecondaryEmailCommand;
+use MsgPhp\User\Command\MarkUserSecondaryEmailPrimaryCommand;
+use MsgPhp\User\Command\SetUserPendingPrimaryEmailCommand;
+use MsgPhp\User\Infra\Security\SecurityUserFactory;
+use MsgPhp\User\Repository\UserSecondaryEmailRepositoryInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Twig\Environment;
+
+final class MyAccountController
+{
+    public function __invoke(
+        SecurityUserFactory $securityUser,
+        TokenStorageInterface $tokenStorage,
+        Request $request,
+        FormFactoryInterface $formFactory,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator,
+        Environment $twig,
+        CommandBusInterface $commandBus,
+        UserSecondaryEmailRepositoryInterface $userSecondaryEmailRepository,
+        SendEmailConfirmationUrlToUser $sendEmailConfirmationUrlToUser,
+        PasswordConfirmation $passwordConfirmation
+    ): Response
+    {
+        if (!$securityUser->isAuthenticated()) {
+            return new RedirectResponse($urlGenerator->generate('login'));
+        }
+
+        // change primary e-mail
+        $emailForm = $formFactory->create(ChangeEmailType::class);
+
+        $emailForm->handleRequest($request);
+
+        if ($emailForm->isSubmitted() && $emailForm->isValid()) {
+            $data = $emailForm->getData();
+
+            $commandBus->handle(new SetUserPendingPrimaryEmailCommand($securityUser->getUserId(), $data['email']));
+            $flashBag->add('success', 'We\'ve send you a confirmation link.');
+
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        // cancel pending primary email
+        if ($request->query->getBoolean('cancel-email')) {
+            if (null !== $confirmResponse = $passwordConfirmation->confirm($request)) {
+                return $confirmResponse;
+            }
+
+            $commandBus->handle(new SetUserPendingPrimaryEmailCommand($securityUser->getUserId(), null));
+            $flashBag->add('success', 'Cancelled pending primary e-mail.');
+
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        // add secondary email
+        $secondaryEmailForm = $formFactory->create(AddSecondaryEmailType::class);
+
+        $secondaryEmailForm->handleRequest($request);
+
+        if ($secondaryEmailForm->isSubmitted() && $secondaryEmailForm->isValid()) {
+            $data = $secondaryEmailForm->getData();
+
+            $commandBus->handle(new AddUserSecondaryEmailCommand($securityUser->getUserId(), $data['email']));
+            $flashBag->add('success', 'We\'ve send you a confirmation link.');
+
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        // mark secondary e-mail primary
+        if ($primaryEmail = $request->query->get('primary-email')) {
+            if (null !== $confirmResponse = $passwordConfirmation->confirm($request)) {
+                return $confirmResponse;
+            }
+
+            $commandBus->handle(new MarkUserSecondaryEmailPrimaryCommand($securityUser->getUserId(), $primaryEmail));
+
+            $currentSecondaryEmail = $userSecondaryEmailRepository->find($securityUser->getUserId(), $primaryEmail);
+            if ($currentSecondaryEmail->getConfirmedAt()) {
+                $flashBag->add('success', 'We\'ve changed your primary e-mail. Please login again.');
+                $tokenStorage->setToken(null);
+
+                return new RedirectResponse($urlGenerator->generate('login'));
+            }
+
+            $flashBag->add('success', sprintf('Marked secondary e-mail "%s" as pending primary.', $primaryEmail));
+
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        // delete secondary e-mail
+        if ($deleteEmail = $request->query->get('delete-email')) {
+            if (null !== $confirmResponse = $passwordConfirmation->confirm($request)) {
+                return $confirmResponse;
+            }
+
+            $commandBus->handle(new DeleteUserSecondaryEmailCommand($securityUser->getUserId(), $deleteEmail));
+            $flashBag->add('success', sprintf('Deleted secondary e-mail "%s".', $deleteEmail));
+
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        // change password
+        $passwordForm = $formFactory->create(ChangePasswordType::class);
+
+        $passwordForm->handleRequest($request);
+
+        if ($passwordForm->isSubmitted() && $passwordForm->isValid()) {
+            $data = $passwordForm->getData();
+
+            $commandBus->handle(new ChangeUserPasswordCommand($securityUser->getUserId(), $data['password']));
+            $flashBag->add('success', 'We\'ve reset your password. Please login again.');
+            $tokenStorage->setToken(null);
+
+            return new RedirectResponse($urlGenerator->generate('login'));
+        }
+
+        // send secondary / pending primary email confirmation link
+        if ($confirmEmail = $request->query->get('confirm-email')) {
+            $currentSecondaryEmail = $userSecondaryEmailRepository->find($securityUser->getUserId(), $confirmEmail);
+            if (!$currentSecondaryEmail->getConfirmedAt()) {
+                $sendEmailConfirmationUrlToUser->notify($currentSecondaryEmail);
+                $flashBag->add('success', 'We\'ve re-send you a confirmation link.');
+            }
+
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        // render view
+        return new Response($twig->render('User/my_account.html.twig', [
+            'emailForm' => $emailForm->createView(),
+            'secondaryEmails' => $userSecondaryEmailRepository->findAllByUserId($securityUser->getUserId()),
+            'secondaryEmailForm' => $secondaryEmailForm->createView(),
+            'passwordForm' => $passwordForm->createView(),
+        ]));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/RegisterController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/RegisterController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Form\User\RegisterType;
+use MsgPhp\Domain\CommandBusInterface;
+use MsgPhp\User\Command\CreatePendingUserCommand;
+use MsgPhp\User\Infra\Security\SecurityUserFactory;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+final class RegisterController
+{
+    public function __invoke(
+        SecurityUserFactory $securityUser,
+        Request $request,
+        FormFactoryInterface $formFactory,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator,
+        Environment $twig,
+        CommandBusInterface $commandBus
+    ): Response
+    {
+        if ($securityUser->isAuthenticated()) {
+            return new RedirectResponse($urlGenerator->generate('my_account'));
+        }
+
+        $form = $formFactory->createNamed('', RegisterType::class);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+
+            $commandBus->handle(new CreatePendingUserCommand($data['email'], $data['password']));
+            $flashBag->add('success', sprintf('Hi %s, we\'ve send you a confirmation link.', $data['email']));
+
+            return new RedirectResponse($urlGenerator->generate('index'));
+        }
+
+        return new Response($twig->render('User/register.html.twig', [
+            'form' => $form->createView(),
+        ]));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Controller/User/ResetPasswordController.php
+++ b/msgphp/user-bundle/0.1/src/Controller/User/ResetPasswordController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Controller\User;
+
+use App\Entity\User\User;
+use App\Form\User\ResetPasswordType;
+use MsgPhp\Domain\CommandBusInterface;
+use MsgPhp\User\Command\ResetUserPasswordCommand;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Twig\Environment;
+
+final class ResetPasswordController
+{
+    /**
+     * @ParamConverter("user", options={"mapping": {"token": "passwordResetToken"}})
+     */
+    public function __invoke(
+        User $user,
+        Request $request,
+        FormFactoryInterface $formFactory,
+        FlashBagInterface $flashBag,
+        UrlGeneratorInterface $urlGenerator,
+        TokenStorageInterface $tokenStorage,
+        Environment $twig,
+        CommandBusInterface $commandBus
+    ): Response
+    {
+        $form = $formFactory->createNamed('', ResetPasswordType::class);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+
+            $commandBus->handle(new ResetUserPasswordCommand($user->getPasswordResetToken(), $data['password']));
+            $flashBag->add('success', 'Hi, we\'ve reset your password. Please login again.');
+            $tokenStorage->setToken(null);
+
+            return new RedirectResponse($urlGenerator->generate('index'));
+        }
+
+        return new Response($twig->render('User/reset_password.html.twig', [
+            'form' => $form->createView(),
+        ]));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/DataFixtures/ORM/Users.php
+++ b/msgphp/user-bundle/0.1/src/DataFixtures/ORM/Users.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\DataFixtures\ORM;
+
+use App\Entity\Eav\Attribute;
+use App\Entity\User\User;
+use App\Entity\User\UserAttributeValue;
+use App\Entity\User\UserRole;
+use App\Security\UserRoleProvider;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\Persistence\ObjectManager;
+use MsgPhp\Eav\Infra\Uuid\AttributeId;
+use MsgPhp\Eav\Infra\Uuid\AttributeValueId;
+use MsgPhp\User\Infra\Security\SecurityUser;
+use MsgPhp\User\Infra\Uuid\UserId;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
+final class Users extends Fixture
+{
+    private const PASSWORD = 'pass';
+
+    public function load(ObjectManager $manager)
+    {
+        $user = $this->createUser('user@domain.dev');
+        $user->enable();
+        $manager->persist($user);
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $boolAttr = new Attribute(new AttributeId()), true));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $boolAttr, false));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $boolAttr, null));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $intAttr = new Attribute(new AttributeId()), 123));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $intAttr, -123));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $floatAttr = new Attribute(new AttributeId()), 123.1223456789));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $floatAttr, -0.123));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $stringAttr = new Attribute(new AttributeId()), 'text'));
+        $manager->persist(new UserAttributeValue(new AttributeValueId(), $user, $dateTimeAttr = new Attribute(new AttributeId()), new \DateTime()));
+
+        $user = $this->createUser('user+disabled@domain.dev');
+        $manager->persist($user);
+
+        $user = $this->createUser('user+admin@domain.dev');
+        $user->enable();
+        $manager->persist($user);
+        $manager->persist(new UserRole($user, UserRoleProvider::ROLE_ADMIN));
+
+        $user = $this->createUser('user+admin+disabled@domain.dev');
+        $manager->persist($user);
+        $manager->persist(new UserRole($user, UserRoleProvider::ROLE_ADMIN));
+
+        $manager->flush();
+    }
+
+    private function createUser(string $email, string $password = self::PASSWORD): User
+    {
+        /** @var EncoderFactoryInterface $encoder */
+        $encoder = $this->container->get('security.encoder_factory');
+
+        return new User(new UserId(), $email, $encoder->getEncoder(SecurityUser::class)->encodePassword($password, null));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Entity/Eav/Attribute.php
+++ b/msgphp/user-bundle/0.1/src/Entity/Eav/Attribute.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\Eav;
+
+use Doctrine\ORM\Mapping as ORM;
+use MsgPhp\Eav\Entity\Attribute as BaseAttribute;
+
+/**
+ * @ORM\Entity()
+ *
+ * @final
+ */
+class Attribute extends BaseAttribute
+{
+}

--- a/msgphp/user-bundle/0.1/src/Entity/User/PendingUser.php
+++ b/msgphp/user-bundle/0.1/src/Entity/User/PendingUser.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\User;
+
+use Doctrine\ORM\Mapping as ORM;
+use MsgPhp\User\Entity\PendingUser as BasePendingUser;
+
+/**
+ * @ORM\Entity()
+ *
+ * @final
+ */
+class PendingUser extends BasePendingUser
+{
+}

--- a/msgphp/user-bundle/0.1/src/Entity/User/User.php
+++ b/msgphp/user-bundle/0.1/src/Entity/User/User.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\User;
+
+use Doctrine\ORM\Mapping as ORM;
+use MsgPhp\User\Entity\User as BaseUser;
+
+/**
+ * @ORM\Entity()
+ *
+ * @final
+ */
+class User extends BaseUser
+{
+}

--- a/msgphp/user-bundle/0.1/src/Entity/User/UserAttributeValue.php
+++ b/msgphp/user-bundle/0.1/src/Entity/User/UserAttributeValue.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\User;
+
+use Doctrine\ORM\Mapping as ORM;
+use MsgPhp\User\Entity\UserAttributeValue as BaseUserAttributeValue;
+
+/**
+ * @ORM\Entity()
+ *
+ * @final
+ */
+class UserAttributeValue extends BaseUserAttributeValue
+{
+}

--- a/msgphp/user-bundle/0.1/src/Entity/User/UserRole.php
+++ b/msgphp/user-bundle/0.1/src/Entity/User/UserRole.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\User;
+
+use Doctrine\ORM\Mapping as ORM;
+use MsgPhp\User\Entity\UserRole as BaseUserRole;
+
+/**
+ * @ORM\Entity()
+ *
+ * @final
+ */
+class UserRole extends BaseUserRole
+{
+}

--- a/msgphp/user-bundle/0.1/src/Entity/User/UserSecondaryEmail.php
+++ b/msgphp/user-bundle/0.1/src/Entity/User/UserSecondaryEmail.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Entity\User;
+
+use Doctrine\ORM\Mapping as ORM;
+use MsgPhp\User\Entity\UserSecondaryEmail as BaseUserSecondaryEmail;
+
+/**
+ * @ORM\Entity()
+ *
+ * @final
+ */
+class UserSecondaryEmail extends BaseUserSecondaryEmail
+{
+}

--- a/msgphp/user-bundle/0.1/src/EventSubscriber/SendAccountConfirmationUrlToPendingUser.php
+++ b/msgphp/user-bundle/0.1/src/EventSubscriber/SendAccountConfirmationUrlToPendingUser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use MsgPhp\User\Entity\PendingUser;
+use MsgPhp\User\Event\PendingUserCreatedEvent;
+use Twig\Environment;
+
+final class SendAccountConfirmationUrlToPendingUser
+{
+    private $mailer;
+    private $twig;
+
+    public function __construct(\Swift_Mailer $mailer, Environment $twig)
+    {
+        $this->mailer = $mailer;
+        $this->twig = $twig;
+    }
+
+    public function __invoke(PendingUserCreatedEvent $event): void
+    {
+        $this->notify($event->pendingUser);
+    }
+
+    public function notify(PendingUser $pendingUser): void
+    {
+        $params = ['pendingUser' => $pendingUser];
+        $message = (new \Swift_Message('Confirm your account at The App'))
+            ->addTo($pendingUser->getEmail())
+            ->setBody($this->twig->render('User/email/confirm_account.txt.twig', $params), 'plain/text')
+            ->addPart($this->twig->render('User/email/confirm_account.html.twig', $params), 'text/html');
+
+        $this->mailer->send($message);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/EventSubscriber/SendEmailConfirmationUrlToUser.php
+++ b/msgphp/user-bundle/0.1/src/EventSubscriber/SendEmailConfirmationUrlToUser.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use MsgPhp\User\Entity\UserSecondaryEmail;
+use MsgPhp\User\Event\UserSecondaryEmailAddedEvent;
+use Twig\Environment;
+
+final class SendEmailConfirmationUrlToUser
+{
+    private $mailer;
+    private $twig;
+
+    public function __construct(\Swift_Mailer $mailer, Environment $twig)
+    {
+        $this->mailer = $mailer;
+        $this->twig = $twig;
+    }
+
+    public function __invoke(UserSecondaryEmailAddedEvent $event): void
+    {
+        if (!$event->userSecondaryEmail->getConfirmedAt()) {
+            $this->notify($event->userSecondaryEmail);
+        }
+    }
+
+    public function notify(UserSecondaryEmail $userSecondaryEmail): void
+    {
+        if ($userSecondaryEmail->getConfirmedAt()) {
+            throw new \LogicException('Cannot notify a secondary user e-mail which is already confirmed.');
+        }
+
+        $params = ['userSecondaryEmail' => $userSecondaryEmail];
+        $message = (new \Swift_Message('Confirm your e-mail at The App'))
+            ->addTo($userSecondaryEmail->getEmail())
+            ->setBody($this->twig->render('User/email/confirm_email.txt.twig', $params), 'plain/text')
+            ->addPart($this->twig->render('User/email/confirm_email.html.twig', $params), 'text/html');
+
+        $this->mailer->send($message);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/EventSubscriber/SendPasswordResetUrlToUser.php
+++ b/msgphp/user-bundle/0.1/src/EventSubscriber/SendPasswordResetUrlToUser.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use MsgPhp\User\Entity\User;
+use MsgPhp\User\Event\UserPasswordRequestedEvent;
+use Twig\Environment;
+
+final class SendPasswordResetUrlToUser
+{
+    private $mailer;
+    private $twig;
+
+    public function __construct(\Swift_Mailer $mailer, Environment $twig)
+    {
+        $this->mailer = $mailer;
+        $this->twig = $twig;
+    }
+
+    public function __invoke(UserPasswordRequestedEvent $event): void
+    {
+        if (null !== $event->user->getPasswordResetToken()) {
+            $this->notify($event->user);
+        }
+    }
+
+    public function notify(User $user): void
+    {
+        if (null === $user->getPasswordResetToken()) {
+            throw new \LogicException('Cannot notify a user without a password reset token.');
+        }
+
+        $params = ['user' => $user];
+        $message = (new \Swift_Message('Reset your password at The App'))
+            ->addTo($user->getEmail())
+            ->setBody($this->twig->render('User/email/reset_password.txt.twig', $params), 'plain/text')
+            ->addPart($this->twig->render('User/email/reset_password.html.twig', $params), 'text/html');
+
+        $this->mailer->send($message);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/AddSecondaryEmailType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/AddSecondaryEmailType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Form\User;
+
+use MsgPhp\User\Infra\Validator\UniqueEmail;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class AddSecondaryEmailType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('email', EmailType::class, [
+            'constraints' => [new NotBlank(), new Email(), new UniqueEmail()],
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/ChangeEmailType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/ChangeEmailType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Form\User;
+
+use MsgPhp\User\Infra\Validator\UniqueEmail;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class ChangeEmailType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('currentPassword', PasswordType::class, [
+            'constraints' => [new UserPassword()],
+        ]);
+        $builder->add('email', EmailType::class, [
+            'constraints' => [new NotBlank(), new Email(), new UniqueEmail()],
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/ChangePasswordType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/ChangePasswordType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Form\User;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class ChangePasswordType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('currentPassword', PasswordType::class, [
+            'constraints' => [new UserPassword()],
+        ]);
+        $builder->add('password', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'constraints' => [new NotBlank()],
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/ForgotPasswordType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/ForgotPasswordType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Form\User;
+
+use MsgPhp\User\Infra\Validator\ExistingEmail;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class ForgotPasswordType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('email', EmailType::class, [
+            'constraints' => [new NotBlank(), new ExistingEmail()],
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/LoginType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/LoginType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Form\User;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class LoginType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('email', EmailType::class);
+        $builder->add('password', PasswordType::class);
+        $builder->add('remember_me', CheckboxType::class, [
+            'required' => false,
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/RegisterType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/RegisterType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Form\User;
+
+use MsgPhp\User\Infra\Validator\UniqueEmail;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class RegisterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('email', EmailType::class, [
+            'constraints' => [new NotBlank(), new Email(), new UniqueEmail()],
+        ]);
+        $builder->add('password', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'constraints' => [new NotBlank()],
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Form/User/ResetPasswordType.php
+++ b/msgphp/user-bundle/0.1/src/Form/User/ResetPasswordType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Form\User;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class ResetPasswordType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('password', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'constraints' => [new NotBlank()],
+        ]);
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Security/UserPasswordConfirmation.php
+++ b/msgphp/user-bundle/0.1/src/Security/UserPasswordConfirmation.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Security;
+
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Twig\Environment;
+
+final class UserPasswordConfirmation
+{
+    private $twig;
+    private $formFactory;
+    private $urlGenerator;
+
+    public function __construct(Environment $twig, FormFactoryInterface $formFactory, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->twig = $twig;
+        $this->formFactory = $formFactory;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function confirm(Request $request): ?Response
+    {
+        if (null === $session = $request->getSession()) {
+            throw new \LogicException('Session not available.');
+        }
+
+        if ($session->has($hash = md5($request->getUriForPath($request->getRequestUri())))) {
+            $session->remove($hash);
+
+            return null;
+        }
+
+        $referer = (null !== $route = $request->attributes->get('_route'))
+            ? $this->urlGenerator->generate($route, $request->attributes->get('_route_params', []), UrlGeneratorInterface::ABSOLUTE_URL)
+            : $request->headers->get('referer');
+
+        $form = $this->formFactory->createNamedBuilder($hash)
+            ->add('password', PasswordType::class, [
+                'required' => true,
+                'constraints' => [new UserPassword()],
+            ])
+            ->add('referer', HiddenType::class, [
+                'data' => $referer,
+            ])
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            if ($form->isValid()) {
+                $session->set($hash, '1');
+
+                return new RedirectResponse($request->getRequestUri());
+            }
+
+            $referer = $form->get('referer')->getData();
+        }
+
+        if (null === $referer || $hash === md5($referer)) {
+            throw new BadRequestHttpException('Unable to confirm current request.');
+        }
+
+        return new Response($this->twig->render('confirm_password.html.twig', [
+            'form' => $form->createView(),
+            'cancelUrl' => $referer,
+        ]));
+    }
+}

--- a/msgphp/user-bundle/0.1/src/Security/UserRoleProvider.php
+++ b/msgphp/user-bundle/0.1/src/Security/UserRoleProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Security;
+
+use MsgPhp\User\Entity\User;
+use MsgPhp\User\Entity\UserRole;
+use MsgPhp\User\Infra\Security\UserRoleProviderInterface;
+use MsgPhp\User\Repository\UserRoleRepositoryInterface;
+
+final class UserRoleProvider implements UserRoleProviderInterface
+{
+    public const ROLE_USER = 'ROLE_USER';
+    public const ROLE_DISABLED_USER = 'ROLE_DISABLED_USER';
+    public const ROLE_ADMIN = 'ROLE_ADMIN';
+
+    private $repository;
+
+    public function __construct(UserRoleRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getRoles(User $user): array
+    {
+        $roles = $user->isEnabled() ? [self::ROLE_USER] : [self::ROLE_DISABLED_USER];
+
+        return array_merge($roles, $this->repository->findAllByUserId($user->getId())->map(function (UserRole $userRole) {
+            return $userRole->getRole();
+        }));
+    }
+}

--- a/msgphp/user-bundle/0.1/templates/User/confirm_password.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/confirm_password.html.twig
@@ -1,0 +1,14 @@
+{% extends 'User/layout.html.twig' %}
+
+{% block body %}
+    <p>Confirm your password to proceed.</p>
+
+    {{ form_start(form) }}
+        {{ form_errors(form) }}
+        {{ form_row(form.password, {label: 'Password'}) }}
+
+        <div>
+            <input type="submit" value="Confirm" /> or <a href="{{ cancelUrl }}">Cancel</a>
+        </div>
+    {{ form_end(form) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/email/confirm_account.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/confirm_account.html.twig
@@ -1,0 +1,6 @@
+{% extends 'User/email/layout.html.twig' %}
+
+{% block body %}
+    {% set url = url('confirm_account', {token: pendingUser.token}) %}
+    <p>Confirm your account at <a href="{{ url }}">{{ url }}</a></p>
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/email/confirm_account.txt.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/confirm_account.txt.twig
@@ -1,0 +1,5 @@
+{% extends 'User/email/layout.txt.twig' %}
+
+{% block body %}
+Confirm your account at {{ url('confirm_account', {token: pendingUser.token}) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/email/confirm_email.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/confirm_email.html.twig
@@ -1,0 +1,6 @@
+{% extends 'User/email/layout.html.twig' %}
+
+{% block body %}
+    {% set url = url('confirm_email', {token: userSecondaryEmail.token}) %}
+    <p>Confirm your e-mail at <a href="{{ url }}">{{ url }}</a></p>
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/email/confirm_email.txt.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/confirm_email.txt.twig
@@ -1,0 +1,5 @@
+{% extends 'User/email/layout.txt.twig' %}
+
+{% block body %}
+Confirm your e-mail at {{ url('confirm_email', {token: userSecondaryEmail.token}) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/email/layout.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/layout.html.twig
@@ -1,0 +1,5 @@
+<p><strong>E-mail from your app:</strong></p>
+
+{% block body %}{% endblock %}
+
+<p>Cheers! <cite>The App</cite>,</p>

--- a/msgphp/user-bundle/0.1/templates/User/email/layout.txt.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/layout.txt.twig
@@ -1,0 +1,8 @@
+E-mail from your app:
+=====================
+
+{% block body %}{% endblock %}
+
+--
+
+Cheers! The App,

--- a/msgphp/user-bundle/0.1/templates/User/email/reset_password.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/reset_password.html.twig
@@ -1,0 +1,6 @@
+{% extends 'User/email/layout.html.twig' %}
+
+{% block body %}
+    {% set url = url('reset_password', {token: user.passwordResetToken}) %}
+    <p>Reset your password at <a href="{{ url }}">{{ url }}</a></p>
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/email/reset_password.txt.twig
+++ b/msgphp/user-bundle/0.1/templates/User/email/reset_password.txt.twig
@@ -1,0 +1,5 @@
+{% extends 'User/email/layout.txt.twig' %}
+
+{% block body %}
+Reset your password at {{ url('reset_password', {token: user.passwordResetToken}) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/forgot_password.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/forgot_password.html.twig
@@ -1,0 +1,12 @@
+{% extends 'User/layout.html.twig' %}
+
+{% block body %}
+    {{ form_start(form) }}
+        {{ form_errors(form) }}
+        {{ form_row(form.email, {label: 'Email'}) }}
+
+        <div>
+            <input type="submit" value="Request password" />
+        </div>
+    {{ form_end(form) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/layout.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/layout.html.twig
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>Welcome!</title>
+    </head>
+    <body>
+        {% set flashes = app.flashes %}
+        {% if flashes|length > 0 %}
+            <ul>
+                {% for label, messages in flashes %}
+                    {% for message in messages %}
+                        <li>[{{ label|upper }}] {{ message }}</li>
+                    {% endfor %}
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        {% block body %}{% endblock %}
+    </body>
+</html>

--- a/msgphp/user-bundle/0.1/templates/User/login.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/login.html.twig
@@ -1,0 +1,14 @@
+{% extends 'User/layout.html.twig' %}
+
+{% block body %}
+    {{ form_start(form) }}
+        {{ form_errors(form) }}
+        {{ form_row(form.email, {label: 'Email'}) }}
+        {{ form_row(form.password, {label: 'Password'}) }}
+        {{ form_row(form.remember_me, {label: 'Remember me'}) }}
+
+        <div>
+            <input type="submit" value="Login" />
+        </div>
+    {{ form_end(form) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/my_account.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/my_account.html.twig
@@ -1,0 +1,80 @@
+{% extends 'User/layout.html.twig' %}
+
+{% block body %}
+    {% set pendingPrimaryEmail = null %}
+    {% for secondaryEmail in secondaryEmails if secondaryEmail.isPendingPrimary %}
+        {% set pendingPrimaryEmail = secondaryEmail.email %}
+    {% endfor %}
+    <fieldset>
+        <legend>Change e-mail</legend>
+        <fieldset>
+            <legend>Primary e-mail</legend>
+            <ul>
+                <li>Current: {{ current_user().email }}</li>
+                {% if pendingPrimaryEmail %}
+                    <li>
+                        Pending confirmation: {{ pendingPrimaryEmail }}
+                        - <a href="{{ path('my_account', {'confirm-email': pendingPrimaryEmail}) }}">Send confirmation link</a>
+                        - <a href="{{ path('my_account', {'cancel-email': true}) }}">Cancel</a>
+                    </li>
+                {% endif %}
+            </ul>
+            {{ form_start(emailForm) }}
+                {{ form_errors(emailForm) }}
+                {{ form_row(emailForm.currentPassword, {label: 'Current password'}) }}
+                {{ form_row(emailForm.email, {label: 'E-mail'}) }}
+
+                <div>
+                    <input type="submit" value="Change primary e-mail" />
+                </div>
+            {{ form_end(emailForm) }}
+        </fieldset>
+
+        <fieldset>
+            <legend>Secondary e-mails</legend>
+            <ul>
+                {% for secondaryEmail in secondaryEmails %}
+                    <li>
+                        {{ secondaryEmail.email }}
+                        {% if secondaryEmail.confirmedAt %}
+                            - Confimed
+                        {% else %}
+                            - Unconfirmed
+                            - <a href="{{ path('my_account', {'confirm-email': secondaryEmail.email}) }}">Send confirmation link</a>
+                        {% endif %}
+                        {% if secondaryEmail.isPendingPrimary %}
+                            - Pending primary
+                        {% else %}
+                            - <a href="{{ path('my_account', {'primary-email': secondaryEmail.email}) }}">Make primary</a>
+                        {% endif %}
+                        - <a href="{{ path('my_account', {'delete-email': secondaryEmail.email}) }}">Delete</a>
+                    </li>
+                {% else %}
+                    <li><em>None</em></li>
+                {% endfor %}
+            </ul>
+            {{ form_start(secondaryEmailForm) }}
+                {{ form_errors(secondaryEmailForm) }}
+                {{ form_row(secondaryEmailForm.email, {label: 'New secondary e-mail'}) }}
+
+                <div>
+                    <input type="submit" value="Add secondary e-mail" />
+                </div>
+            {{ form_end(secondaryEmailForm) }}
+        </fieldset>
+    </fieldset>
+
+    <fieldset>
+        <legend>Change password</legend>
+        {{ form_start(passwordForm) }}
+            {{ form_errors(passwordForm) }}
+            {{ form_row(passwordForm.currentPassword, {label: 'Current password'}) }}
+            {{ form_row(passwordForm.password.first, {label: 'New password'}) }}
+            {{ form_row(passwordForm.password.second, {label: 'Confirm new password'}) }}
+
+            <div>
+                <input type="submit" value="Change password" />
+            </div>
+        {{ form_end(passwordForm) }}
+    </fieldset>
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/register.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/register.html.twig
@@ -1,0 +1,14 @@
+{% extends 'User/layout.html.twig' %}
+
+{% block body %}
+    {{ form_start(form) }}
+        {{ form_errors(form) }}
+        {{ form_row(form.email, {label: 'Email'}) }}
+        {{ form_row(form.password.first, {label: 'Password'}) }}
+        {{ form_row(form.password.second, {label: 'Confirm password'}) }}
+
+        <div>
+            <input type="submit" value="Register" />
+        </div>
+    {{ form_end(form) }}
+{% endblock %}

--- a/msgphp/user-bundle/0.1/templates/User/reset_password.html.twig
+++ b/msgphp/user-bundle/0.1/templates/User/reset_password.html.twig
@@ -1,0 +1,13 @@
+{% extends 'User/layout.html.twig' %}
+
+{% block body %}
+    {{ form_start(form) }}
+        {{ form_errors(form) }}
+        {{ form_row(form.password.first, {label: 'New password'}) }}
+        {{ form_row(form.password.second, {label: 'Confirm new password'}) }}
+
+        <div>
+            <input type="submit" value="Reset password" />
+        </div>
+    {{ form_end(form) }}
+{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This is my personal work to provide a starter-kit for some user aware application. See also https://github.com/msgphp/symfony-demo-app

It's a bit opinionated perhaps, but im curious if anyone finds this useful. And of course wanna see SF recipes in action :)

I've used the current deps to provide all infra;

```json
"minimum-stability": "dev",
"require": {
    "msgphp/eav": "^1.0",
    "msgphp/user-bundle": "^0.1",
    "ramsey/uuid": "^3.7",
    "sensio/framework-extra-bundle": "^5.0",
    "simple-bus/symfony-bridge": "^5.0",
    "symfony/console": "^3.4",
    "symfony/flex": "^1.0",
    "symfony/form": "^3.4",
    "symfony/framework-bundle": "^3.4",
    "symfony/monolog-bundle": "^3.1",
    "symfony/orm-pack": "^1.0",
    "symfony/security-bundle": "^3.4",
    "symfony/security-csrf": "^3.4",
    "symfony/swiftmailer-bundle": "^3.1",
    "symfony/validator": "^3.4"
}
```