### PR TITLE
Add PHP-CS-Fixer recipe

### DIFF
--- a/friendsofphp/php-cs-fixer/2.7/.php_cs.dist
+++ b/friendsofphp/php-cs-fixer/2.7/.php_cs.dist
@@ -1,0 +1,71 @@
+<?php
+
+$header = <<<'EOF'
+This file is part of PHP CS Fixer.
+
+(c) Fabien Potencier <fabien@symfony.com>
+    Dariusz Rumiński <dariusz.ruminski@gmail.com>
+
+This source file is subject to the MIT license that is bundled
+with this source code in the file LICENSE.
+EOF;
+
+$config = PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PHP56Migration' => true,
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'align_multiline_comment' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'blank_line_before_statement' => true,
+        'combine_consecutive_issets' => true,
+        'combine_consecutive_unsets' => true,
+        // one should use PHPUnit methods to set up expected exception instead of annotations
+        'general_phpdoc_annotation_remove' => ['annotations' => ['expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp']],
+        'header_comment' => ['header' => $header],
+        'heredoc_to_nowdoc' => true,
+        'list_syntax' => ['syntax' => 'long'],
+        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'no_extra_consecutive_blank_lines' => ['tokens' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block']],
+        'no_null_property_initialization' => true,
+        'no_short_echo_tag' => true,
+        'no_superfluous_elseif' => true,
+        'no_unneeded_curly_braces' => true,
+        'no_unneeded_final_method' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'php_unit_strict' => true,
+        'php_unit_test_class_requires_covers' => true,
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_order' => true,
+        'phpdoc_types_order' => true,
+        'semicolon_after_instruction' => true,
+        'single_line_comment_style' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+        'yoda_style' => true,
+    ])
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->exclude('tests/Fixtures')
+            ->in(__DIR__)
+    )
+;
+
+// special handling of fabbot.io service if it's using too old PHP CS Fixer version
+try {
+    PhpCsFixer\FixerFactory::create()
+        ->registerBuiltInFixers()
+        ->registerCustomFixers($config->getCustomFixers())
+        ->useRuleSet(new PhpCsFixer\RuleSet($config->getRules()));
+} catch (PhpCsFixer\ConfigurationException\InvalidConfigurationException $e) {
+    $config->setRules([]);
+} catch (UnexpectedValueException $e) {
+    $config->setRules([]);
+}
+
+return $config;

--- a/friendsofphp/php-cs-fixer/2.7/manifest.json
+++ b/friendsofphp/php-cs-fixer/2.7/manifest.json
@@ -1,0 +1,9 @@
+{
+    "copy-from-recipe": {
+        ".php_cs.dist": ".php_cs.dist"
+    },
+    "gitignore": [
+        ".php_cs",
+        ".php_cs.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Add recipe for the [PHP-CS-Fixer](http://github.com/friendsofphp/php-cs-fixer) lib.