### PR TITLE
OverblogGraphQLBundle: Updated recipe to support version 0.11.* 

### DIFF
--- a/overblog/graphql-bundle/0.11/config/packages/graphql.yaml
+++ b/overblog/graphql-bundle/0.11/config/packages/graphql.yaml
@@ -1,0 +1,11 @@
+overblog_graphql:
+    definitions:
+        schema:
+            query: Query
+        mappings:
+            auto_discover: false
+            types:
+                -
+                    type: yaml
+                    dir: "%kernel.project_dir%/config/graphql/types"
+                    suffix: ~

--- a/overblog/graphql-bundle/0.11/config/routes/graphql.yaml
+++ b/overblog/graphql-bundle/0.11/config/routes/graphql.yaml
@@ -1,0 +1,2 @@
+overblog_graphql_endpoint:
+    resource: "@OverblogGraphQLBundle/Resources/config/routing/graphql.yml"

--- a/overblog/graphql-bundle/0.11/manifest.json
+++ b/overblog/graphql-bundle/0.11/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Overblog\\GraphQLBundle\\OverblogGraphQLBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/overblog/graphql-bundle/0.11/post-install.txt
+++ b/overblog/graphql-bundle/0.11/post-install.txt
@@ -1,0 +1,4 @@
+<bg=blue;fg=white> Next for OverblogGraphQLBundle </>
+    1. Define your schema, read documentation <comment>https://github.com/overblog/GraphQLBundle/blob/master/Resources/doc/definitions/index.md</>
+    2. If you want to see your dumped schema (really not necessary for bootstrap): run <comment>bin/console graphql:dump-schema</comment>
+    3. If you want to have GraphiQL to browse your API run: <comment>composer req --dev overblog/graphiql-bundle</comment>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

## Context
- OverblogGraphQLBundle doesn't have GraphiQL embed anymore, this version won't load the dev route
- Also updated post-install.txt

## TODO
- [ ] Waiting for: https://github.com/overblog/GraphQLBundle/issues/199