### PR TITLE
Add the sroze/openwhisk-bundle recipe

### DIFF
--- a/sroze/openwhisk-bundle/0.2/index.php
+++ b/sroze/openwhisk-bundle/0.2/index.php
@@ -1,0 +1,43 @@
+<?php
+
+// This file is the entry point for your Openwhisk function (also called action)
+
+use App\Kernel;
+use Sam\Openwhisk\Bridge\Symfony\RequestFactory;
+use Sam\Openwhisk\Bridge\Symfony\ResponseFactory;
+use Symfony\Component\Debug\Debug;
+use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+function handle_request(Request $request) : Response
+{
+    if (!isset($_SERVER['APP_ENV'])) {
+        (new Dotenv())->load(__DIR__.'/.env');
+    }
+
+    if ($_SERVER['APP_DEBUG'] ?? false) {
+        umask(0000);
+
+        Debug::enable();
+    }
+
+    $kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', $_SERVER['APP_DEBUG'] ?? false);
+    $response = $kernel->handle($request);
+
+    $kernel->terminate($request, $response);
+
+    return $response;
+}
+
+function main(array $args) : array
+{
+    try {
+        $request = RequestFactory::fromArgs($args);
+        $response = handle_request($request);
+
+        return ResponseFactory::fromHttpFoundationResponse($response);
+    } catch (\Throwable $e) {
+        return ResponseFactory::fromException($e);
+    }
+}

--- a/sroze/openwhisk-bundle/0.2/manifest.json
+++ b/sroze/openwhisk-bundle/0.2/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "index.php": "index.php"
+    }
+}

--- a/sroze/openwhisk-bundle/0.2/manifest.json
+++ b/sroze/openwhisk-bundle/0.2/manifest.json
@@ -1,5 +1,9 @@
 {
     "copy-from-recipe": {
         "index.php": "index.php"
-    }
+    },
+    "gitignore": [
+        "/.serverless",
+        "/node_modules"
+    ]
 }

--- a/sroze/openwhisk-bundle/0.2/manifest.json
+++ b/sroze/openwhisk-bundle/0.2/manifest.json
@@ -1,9 +1,5 @@
 {
     "copy-from-recipe": {
         "index.php": "index.php"
-    },
-    "gitignore": [
-        "/.serverless",
-        "/node_modules"
-    ]
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This recipe will automatically create the Openwhisk entry point for the action (or "cloud function").
This makes Symfony deployable to Openwhisk in almost one `composer req`.

Replaces #124 because of the issue #125.