### PR TITLE
Add Sentry 1.0

### DIFF
--- a/sentry/sentry-symfony/1.0/config/packages/prod/sentry.yaml
+++ b/sentry/sentry-symfony/1.0/config/packages/prod/sentry.yaml
@@ -1,0 +1,2 @@
+sentry:
+    dsn: '%env(SENTRY_DSN)%'

--- a/sentry/sentry-symfony/1.0/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/1.0/config/packages/sentry.yaml
@@ -1,0 +1,8 @@
+sentry:
+    options:
+        curl_method: async
+
+#    skip_capture:  # To skip certain exceptions, specify a list below
+#      - 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException'
+#      - 'Symfony\Component\HttpKernel\Exception\BadRequestHttpException'
+#      - 'Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException'

--- a/sentry/sentry-symfony/1.0/manifest.json
+++ b/sentry/sentry-symfony/1.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Sentry\\SentryBundle\\SentryBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "SENTRY_DSN": ""
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This adds Sentry ~0.8~ 1.0 support. 

The difference with #40 is:
* It uses ~0.8~ 1.0 instead of 0.7
* It is installed always, so not only in `prod`. This is handy, because it allows you to depend on `SentrySymfonyClient` in all environments. Only in prod it's filled with the `SENTRY_DSN` so that it will send reports to Sentry.
* It uses `curl_method: async` by default, which is better if you ask me. It doesn't block the requests for the end-user when an exception occurs, but moves it to a shutdown listener.