### PR TITLE
Add ElasticsearchBundle recipe

### DIFF
--- a/ongr/elasticsearch-bundle/5.0/config/packages/ongr_elasticsearch.yaml
+++ b/ongr/elasticsearch-bundle/5.0/config/packages/ongr_elasticsearch.yaml
@@ -1,0 +1,10 @@
+# Read the documentation: http://docs.ongr.io/ElasticsearchBundle
+ongr_elasticsearch:
+    managers:
+        default:
+            index:
+                hosts:
+                    - 127.0.0.1:9200
+                index_name: my-app-index
+            mappings:
+                - AppBundle

--- a/ongr/elasticsearch-bundle/5.0/manifest.json
+++ b/ongr/elasticsearch-bundle/5.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "ONGR\\ElasticsearchBundle\\ONGRElasticsearchBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This bundle provides extensive integration with the official elasticsearch client library.
