### PR TITLE
Add spiechu symfony commons bundle

### DIFF
--- a/spiechu/symfony-commons-bundle/0.1/config/packages/spiechu_symfony_commons.yaml
+++ b/spiechu/symfony-commons-bundle/0.1/config/packages/spiechu_symfony_commons.yaml
@@ -1,0 +1,24 @@
+spiechu_symfony_commons:
+    get_method_override:
+        enabled:              false
+        #listener_service_id:  spiechu_symfony_commons.event_listener.get_method_override_listener
+        #query_param_name:     _method
+        #allow_methods_override:
+            # Defaults:
+            #- DELETE
+            #- POST
+            #- PUT
+    response_schema_validation:
+        enabled:              false
+        #throw_exception_when_format_not_found: true
+        #failed_schema_check_listener_service_id: spiechu_symfony_commons.event_listener.failed_schema_check_listener
+        #disable_json_check_schema_subscriber: false
+        #disable_xml_check_schema_subscriber: false
+    api_versioning:
+        enabled:              false
+        #versioned_view_listener: false
+        #features:
+            # Prototype
+            #name: # non empty string
+            #    since:                null # null or numeric for eg. 1.0
+            #    until:                null # null or numeric for eg. 1.1

--- a/spiechu/symfony-commons-bundle/0.1/config/packages/spiechu_symfony_commons.yaml
+++ b/spiechu/symfony-commons-bundle/0.1/config/packages/spiechu_symfony_commons.yaml
@@ -1,24 +1,9 @@
 spiechu_symfony_commons:
+    # bundle configuration available at
+    # https://github.com/spiechu/symfony-commons-bundle/blob/master/README.md
     get_method_override:
         enabled:              false
-        #listener_service_id:  spiechu_symfony_commons.event_listener.get_method_override_listener
-        #query_param_name:     _method
-        #allow_methods_override:
-            # Defaults:
-            #- DELETE
-            #- POST
-            #- PUT
     response_schema_validation:
         enabled:              false
-        #throw_exception_when_format_not_found: true
-        #failed_schema_check_listener_service_id: spiechu_symfony_commons.event_listener.failed_schema_check_listener
-        #disable_json_check_schema_subscriber: false
-        #disable_xml_check_schema_subscriber: false
     api_versioning:
         enabled:              false
-        #versioned_view_listener: false
-        #features:
-            # Prototype
-            #name: # non empty string
-            #    since:                null # null or numeric for eg. 1.0
-            #    until:                null # null or numeric for eg. 1.1

--- a/spiechu/symfony-commons-bundle/0.1/manifest.json
+++ b/spiechu/symfony-commons-bundle/0.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Spiechu\\SymfonyCommonsBundle\\SpiechuSymfonyCommonsBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Bundle allows to validate JSON / XML responses against given JSON Schema / XSD files using simple controller annotations.
Also allows API versioning and provides compatibility with JMSSerializerBundle `since-version` & `until-version` attributes.

Notice that JMSSerializerBundle and FOSRestBundle are not yet fully compatible with Symfony 4.