### PR TITLE
The new relic recipe is using a wrong bundle name

### DIFF
--- a/ekino/newrelic-bundle/1.3/manifest.json
+++ b/ekino/newrelic-bundle/1.3/manifest.json
@@ -1,6 +1,6 @@
 {
     "bundles": {
-        "Ekino\\Bundle\\NewRelicBundle\\NewRelicBundle": ["prod"]
+        "Ekino\\Bundle\\NewRelicBundle\\EkinoNewRelicBundle": ["prod"]
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

EkinoNewRelicBundle vs NewRelicBundle

See https://github.com/ekino/EkinoNewRelicBundle/blob/master/EkinoNewRelicBundle.php
