### PR TITLE
Adding BCCCronManagerBundle 3.1 recipe

### DIFF
--- a/bcc/cron-manager-bundle/3.1/config/packages/bcc_cron_manager_bundle.yaml
+++ b/bcc/cron-manager-bundle/3.1/config/packages/bcc_cron_manager_bundle.yaml
@@ -1,3 +1,0 @@
-security:
-    access_control:
-        - { path: ^/admin, roles: ROLE_USER }

--- a/bcc/cron-manager-bundle/3.1/config/packages/bcc_cron_manager_bundle.yaml
+++ b/bcc/cron-manager-bundle/3.1/config/packages/bcc_cron_manager_bundle.yaml
@@ -1,0 +1,3 @@
+security:
+    access_control:
+        - { path: ^/admin, roles: ROLE_USER }

--- a/bcc/cron-manager-bundle/3.1/config/routes/bcc_cron_manager_bundle.yaml
+++ b/bcc/cron-manager-bundle/3.1/config/routes/bcc_cron_manager_bundle.yaml
@@ -1,0 +1,3 @@
+BCCCronManagerBundle:
+    resource: "@BCCCronManagerBundle/Resources/config/routing.xml"
+    prefix:   admin/cron-manager

--- a/bcc/cron-manager-bundle/3.1/manifest.json
+++ b/bcc/cron-manager-bundle/3.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "BCC\\CronManagerBundle\\BCCCronManagerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/bcc/cron-manager-bundle/3.1/post-install.txt
+++ b/bcc/cron-manager-bundle/3.1/post-install.txt
@@ -1,1 +1,9 @@
-<fg=blue>BCC Cron Manager Bundle</> needs sessions enabled, please configure this by uncommenting this entire session section in <comment>config/packages/framework.yaml</>.
+<bg=blue;fg=white>                                          </>
+<bg=blue;fg=white> What's next for BCC Cron Manager Bundle? </>
+<bg=blue;fg=white>                                          </>
+
+  * <fg=blue>Configure</> your application:
+    1. Enable sessions by uncommenting the entire session section in <comment>config/packages/framework.yaml</>
+    2. Secure your route by adding <comment>- { path: ^/admin, role: ROLE_ADMIN }</> in your security access_control section.
+
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/michelsalib/BCCCronManagerBundle/blob/master/README.markdown</> 

--- a/bcc/cron-manager-bundle/3.1/post-install.txt
+++ b/bcc/cron-manager-bundle/3.1/post-install.txt
@@ -1,0 +1,1 @@
+<fg=blue>BCC Cron Manager Bundle</> needs sessions enabled, please configure this by uncommenting this entire session section in <comment>config/packages/framework.yaml</>.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR adds recipes for the BCCCronManagerBundle 3.1 (https://github.com/michelsalib/BCCCronManagerBundle/pull/82 and https://github.com/michelsalib/BCCCronManagerBundle/pull/84)


