### PR TITLE
Adding BCCCronManagerBundle 2.6 recipe

### DIFF
--- a/bcc/cron-manager-bundle/2.6/config/packages/bcc_cron_manager_bundle.yaml
+++ b/bcc/cron-manager-bundle/2.6/config/packages/bcc_cron_manager_bundle.yaml
@@ -1,0 +1,3 @@
+security:
+    access_control:
+        - { path: ^/admin, roles: ROLE_USER }

--- a/bcc/cron-manager-bundle/2.6/config/routes/bcc_cron_manager_bundle.yaml
+++ b/bcc/cron-manager-bundle/2.6/config/routes/bcc_cron_manager_bundle.yaml
@@ -1,0 +1,3 @@
+BCCCronManagerBundle:
+    resource: "@BCCCronManagerBundle/Resources/config/routing.xml"
+    prefix:   admin/cron-manager

--- a/bcc/cron-manager-bundle/2.6/manifest.json
+++ b/bcc/cron-manager-bundle/2.6/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "BCC\\CronManagerBundle\\BCCCronManagerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR adds recipes for the BCCCronManagerBundle 2.6 (https://github.com/michelsalib/BCCCronManagerBundle/pull/82 and https://github.com/michelsalib/BCCCronManagerBundle/pull/84)


