### PR TITLE
Fix config for eightpoints/guzzle-bundle

### DIFF
--- a/eightpoints/guzzle-bundle/7.0/config/packages/eight_points_guzzle.yaml
+++ b/eightpoints/guzzle-bundle/7.0/config/packages/eight_points_guzzle.yaml
@@ -12,6 +12,6 @@ eight_points_guzzle:
                 headers:
                     User-Agent: "EightpointsGuzzleBundle/7.0"
 
-                # Find plugins here:
-                # https://github.com/8p/EightPointsGuzzleBundle#known-and-supported-plugins
-                plugin: ~
+            # Find plugins here:
+            # https://github.com/8p/EightPointsGuzzleBundle#known-and-supported-plugins
+            plugin: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Description: `plugin` option should be on the same level with `options`.
Reference: https://github.com/8p/EightPointsGuzzleBundle#usage
Fix issue: #145