### PR TITLE
Add recipe for mmoreram/gearman-bundle 4.1+

### DIFF
--- a/mmoreram/gearman-bundle/4.1/config/packages/gearman.yaml
+++ b/mmoreram/gearman-bundle/4.1/config/packages/gearman.yaml
@@ -1,0 +1,17 @@
+doctrine_cache:
+    providers:
+        gearman_cache:
+            type: file_system
+            namespace: doctrine_cache.ns.gearman
+
+# For full configuration reference please see:
+# http://gearmanbundle.readthedocs.io/en/latest/configuration.html
+#
+# At least you need to provide `resources` or `bundles` configuration in order for your
+# worker annotations to be disoverable.
+gearman:
+    servers:
+        localhost:
+            host: 127.0.0.1
+            port: 4730
+

--- a/mmoreram/gearman-bundle/4.1/manifest.json
+++ b/mmoreram/gearman-bundle/4.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Mmoreram\\GearmanBundle\\GearmanBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/sg/datatablesbundle/1.0/config/routes/sg_datatables_bundle.yaml
+++ b/sg/datatablesbundle/1.0/config/routes/sg_datatables_bundle.yaml
@@ -1,3 +1,4 @@
 sg_datatables_bundle:
     resource: "@SgDatatablesBundle/Controller/"
     type:     annotation
+    prefix:   /sg

--- a/sg/datatablesbundle/1.0/config/routes/sg_datatables_bundle.yaml
+++ b/sg/datatablesbundle/1.0/config/routes/sg_datatables_bundle.yaml
@@ -1,0 +1,3 @@
+sg_datatables_bundle:
+    resource: "@SgDatatablesBundle/Controller/"
+    type:     annotation

--- a/sg/datatablesbundle/1.0/manifest.json
+++ b/sg/datatablesbundle/1.0/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Sg\\DatatablesBundle\\SgDatatablesBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["sg-datatables"]
+}

--- a/sg/datatablesbundle/1.0/manifest.json
+++ b/sg/datatablesbundle/1.0/manifest.json
@@ -5,5 +5,9 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     },
+    "composer-scripts": {
+        "make cache-warmup": "script",
+        "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
+    },    
     "aliases": ["sg-datatables"]
 }

--- a/sg/datatablesbundle/1.0/manifest.json
+++ b/sg/datatablesbundle/1.0/manifest.json
@@ -4,9 +4,5 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    },
-    "composer-scripts": {
-        "make cache-warmup": "script",
-        "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
     }
 }

--- a/sg/datatablesbundle/1.0/manifest.json
+++ b/sg/datatablesbundle/1.0/manifest.json
@@ -8,6 +8,5 @@
     "composer-scripts": {
         "make cache-warmup": "script",
         "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
-    },    
-    "aliases": ["sg-datatables"]
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Adds recipe for gearman-bundle. The 4.1 tag does not yet exist but is underway and will support symfony 4.0. Adding doctrine cache provider this way is safe because this config key is merged.
