### PR TITLE
Add recipe for mmoreram/gearman-bundle 4.1+

### DIFF
--- a/mmoreram/gearman-bundle/4.1/config/packages/gearman.yaml
+++ b/mmoreram/gearman-bundle/4.1/config/packages/gearman.yaml
@@ -8,7 +8,7 @@ doctrine_cache:
 # http://gearmanbundle.readthedocs.io/en/latest/configuration.html
 #
 # At least you need to provide `resources` or `bundles` configuration in order for your
-# worker annotations to be disoverable.
+# worker annotations to be discoverable.
 gearman:
     servers:
         localhost:

--- a/mmoreram/gearman-bundle/4.1/config/packages/gearman.yaml
+++ b/mmoreram/gearman-bundle/4.1/config/packages/gearman.yaml
@@ -1,0 +1,17 @@
+doctrine_cache:
+    providers:
+        gearman_cache:
+            type: file_system
+            namespace: doctrine_cache.ns.gearman
+
+# For full configuration reference please see:
+# http://gearmanbundle.readthedocs.io/en/latest/configuration.html
+#
+# At least you need to provide `resources` or `bundles` configuration in order for your
+# worker annotations to be disoverable.
+gearman:
+    servers:
+        localhost:
+            host: 127.0.0.1
+            port: 4730
+

--- a/mmoreram/gearman-bundle/4.1/manifest.json
+++ b/mmoreram/gearman-bundle/4.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Mmoreram\\GearmanBundle\\GearmanBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Adds recipe for gearman-bundle. Adding doctrine cache provider this way is safe because this config key is merged.
