### PR TITLE
[WIP] made hardcoded paths configurable

### DIFF
--- a/doctrine/mongodb-odm-bundle/3.3/config/packages/doctrine_mongodb.yaml
+++ b/doctrine/mongodb-odm-bundle/3.3/config/packages/doctrine_mongodb.yaml
@@ -13,6 +13,6 @@ doctrine_mongodb:
                 App:
                     is_bundle: false
                     type: annotation
-                    dir: '%kernel.project_dir%/src/Document'
+                    dir: '%kernel.project_dir%/%SRC_DIR%/Document'
                     prefix: App\Document\
                     alias: App

--- a/orbitale/easyimpress-bundle/1.0/config/packages/orbitale_easy_impress.yaml
+++ b/orbitale/easyimpress-bundle/1.0/config/packages/orbitale_easy_impress.yaml
@@ -1,2 +1,2 @@
 easy_impress:
-    presentations_dir: '%kernel.project_dir%/config/presentations'
+    presentations_dir: '%kernel.project_dir%/%CONFIG_DIR%/presentations'

--- a/overblog/graphql-bundle/0.9/config/packages/graphql.yaml
+++ b/overblog/graphql-bundle/0.9/config/packages/graphql.yaml
@@ -7,5 +7,5 @@ overblog_graphql:
             types:
                 -
                     type: yaml
-                    dir: "%kernel.project_dir%/config/graphql/types"
+                    dir: "%kernel.project_dir%/%CONFIG_DIR%/graphql/types"
                     suffix: ~

--- a/php-translation/symfony-bundle/0.4/config/packages/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.4/config/packages/php_translation.yaml
@@ -5,7 +5,7 @@ translation:
         config_name: app
     configs:
         app:
-            dirs: ["%kernel.project_dir%/templates", "%kernel.root_dir%/src"]
+            dirs: ["%kernel.project_dir%/templates", "%kernel.root_dir%/%SRC_DIR%"]
             output_dir: "%kernel.project_dir%/translations"
             excluded_names: ["*TestCase.php", "*Test.php"]
             excluded_dirs: [cache, data, logs]

--- a/vich/uploader-bundle/1.5/config/packages/vich_uploader.yaml
+++ b/vich/uploader-bundle/1.5/config/packages/vich_uploader.yaml
@@ -4,4 +4,4 @@ vich_uploader:
     #mappings:
     #    products:
     #        uri_prefix: /images/products
-    #        upload_destination: '%kernel.project_dir%/public/images/products'
+    #        upload_destination: '%kernel.project_dir%/%PUBLIC_DIR%/images/products'

--- a/wisembly/amqp-bundle/1.3/config/packages/wisembly_amqp.yaml
+++ b/wisembly/amqp-bundle/1.3/config/packages/wisembly_amqp.yaml
@@ -1,5 +1,5 @@
 wisembly_amqp:
-    console_path: '%kernel.project_dir%/bin/console'
+    console_path: '%kernel.project_dir%/%BIN_DIR%/console'
     broker: 'oldsound'
     connections:
         default: '%env(AMQP_URL)%'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT


Comes hand in hand with https://github.com/symfony/flex/pull/204/files
The goal ist, to have the configuration variables (like `%SRC_DIR%` and `%CONFIG_DIR%` also available inside of the files, that are copied. More information inside the PR from Flex-Plugin