### PR TITLE
Forbid method switching

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -62,7 +62,7 @@ DirectoryIndex index.php
         # When mod_rewrite is not available, we instruct a temporary redirect of
         # the start page to the front controller explicitly so that the website
         # and the generated links can still be used.
-        RedirectMatch 302 ^/$ /index.php/
+        RedirectMatch 307 ^/$ /index.php/
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>


### PR DESCRIPTION
This averts the following scenario:

1. Client POSTs
2. server does not support mod rewrite and 302 redirects to /index.php/theaction
3. client follows, but with a GET
4. 405

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
