### PR TITLE
DoctrineFixturesBundle: Remove recipe, we have one in core

### DIFF
--- a/doctrine/doctrine-fixtures-bundle/2.4/manifest.json
+++ b/doctrine/doctrine-fixtures-bundle/2.4/manifest.json
@@ -1,8 +1,0 @@
-{
-    "bundles": {
-        "Doctrine\\Bundle\\FixturesBundle\\DoctrineFixturesBundle": ["dev", "test"]
-    },
-    "copy-from-recipe": {
-        "src/": "%SRC_DIR%/"
-    }
-}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

See: https://github.com/symfony/recipes/pull/286#issuecomment-348217053

I'm not sure if removing this old recipe is strictly required, but it was requested by fabbot (perhaps it's not allowed to have recipes for the same repo on both `recipes` and `recipes-contrib`. It's a little bit confusing at the very least :).
