### PR TITLE
Added recipe for WouterJEloquentBundle

### DIFF
--- a/wouterj/eloquent-bundle/1.0/config/packages/eloquent.yaml
+++ b/wouterj/eloquent-bundle/1.0/config/packages/eloquent.yaml
@@ -1,0 +1,9 @@
+wouterj_eloquent:
+    driver:   '%env(DB_CONNECTION)%'
+    host:     '%env(DB_HOST)%'
+    port:     '%env(DB_PORT)%'
+    database: '%env(DB_DATABASE)%'
+    username: '%env(DB_USERNAME)%'
+    password: '%env(DB_PASSWORD)%'
+    # Uncomment the following line to enable the Eloquent ORM
+    #eloquent: ~

--- a/wouterj/eloquent-bundle/1.0/manifest.json
+++ b/wouterj/eloquent-bundle/1.0/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "WouterJ\\EloquentBundle\\WouterJEloquentBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    },
+    "env": {
+        "DB_CONNECTION": "mysql",
+        "DB_HOST": "127.0.0.1",
+        "DB_PORT": "3306",
+        "DB_DATABASE": "symfony",
+        "DB_USERNAME": "root",
+        "DB_PASSWORD": ""
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This adds a recipe for the WouterJEloquentBundle 1.0.0 release, which supports Symfony 4.

 * The configuration is split up in multiple env variables. Eloquent doesn't yet support a URL setting. And [Laravel](https://github.com/laravel/laravel/blob/master/.env.example#L8-L13) splits them up in these variables as well. The values of the variables are equal to the values used in the DoctrineBundle recipe.
 * The `eloquent: ~` line is commented because you can use only Illuminate database with this package (just as Doctrine DBAL). However, I think most users will use Eloquent ORM when installing the bundle.