### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.json]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In PhpStorm, the default indentation for JSON files is 2 spaces, which may be why most new PR start by getting a validation error complaining about indentation.

Many IDEs (including PhpStorm) support EditorConfig today. This file will ensure that any contributor using such an IDE will get the right JSON indentation from the start in the IDE.
