### PR TITLE
[LiipImagineBundle] Set default web directory path to public/

### DIFF
--- a/liip/imagine-bundle/1.8/config/packages/imagine.yaml
+++ b/liip/imagine-bundle/1.8/config/packages/imagine.yaml
@@ -1,4 +1,15 @@
-#liip_imagine:
+liip_imagine:
+    resolvers:
+        default:
+            web_path:
+                web_root: '%kernel.project_dir%/public'
+                cache_prefix: ~ # media/cache
+
+    loaders:
+        default:
+            filesystem:
+                data_root: '%kernel.project_dir%/public'
+#
 #    # valid drivers options include "gd" or "gmagick" or "imagick"
 #    driver: "gd"
 #


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

LiipImagineBundle doesn't work out of the box with Flex because the web directory is configured to use the `web/` directory by default in the bundle, while Flex directory structure uses `public/`.

This PR adds configuration to use the correct folder.
