### PR TITLE
Adding mmucklo/grid-bundle

### DIFF
--- a/mmucklo/grid-bundle/4.0/config/packages/dtc_grid.yaml
+++ b/mmucklo/grid-bundle/4.0/config/packages/dtc_grid.yaml
@@ -1,0 +1,19 @@
+dtc_grid:
+    purl: 'https://cdnjs.cloudflare.com/ajax/libs/purl/2.3.1/purl.min.js'
+    jquery:
+        url: 'https://code.jquery.com/jquery-3.2.1.min.js'
+        integrity: sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=
+        crossorigin: anonymous
+    datatables:
+        css:
+            - 'https://cdn.datatables.net/1.10.16/css/dataTables.bootstrap.min.css'
+        js:
+            - 'https://cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js'
+            - 'https://cdn.datatables.net/1.10.16/js/dataTables.bootstrap.min.js'
+    theme:
+        css:
+            - 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css'
+            - 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'
+        js:
+            - 'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js'
+    page_div_style: 'margin: 10px'

--- a/mmucklo/grid-bundle/4.0/config/routes/dtc_grid.yaml
+++ b/mmucklo/grid-bundle/4.0/config/routes/dtc_grid.yaml
@@ -1,0 +1,2 @@
+dtc_grid:
+    resource: '@DtcGridBundle/Resources/config/routing.yml'

--- a/mmucklo/grid-bundle/4.0/manifest.json
+++ b/mmucklo/grid-bundle/4.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Dtc\\GridBundle\\DtcGridBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/mmucklo/grid-bundle/4.0/post-install.txt
+++ b/mmucklo/grid-bundle/4.0/post-install.txt
@@ -2,9 +2,9 @@
 <bg=blue;fg=white> What's next? </>
 <bg=blue;fg=white>              </>
 
-  * Warning: make sure the twig engine is turned on in framework.yaml
+Warning: make sure the twig engine is turned on in framework.yaml
 
-    - If not, add the following to config/packages/framework.yaml:
+  - If not, add the following to config/packages/framework.yaml:
 
 framework:
     # ...

--- a/mmucklo/grid-bundle/4.0/post-install.txt
+++ b/mmucklo/grid-bundle/4.0/post-install.txt
@@ -1,0 +1,17 @@
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> What's next? </>
+<bg=blue;fg=white>              </>
+
+  * <fg=orange>Warning:</> make sure the twig engine is turned on in framework.yaml
+
+    - If not, <fg=blue>add</> the following to config/packages/framework.yaml:
+
+<fg=blue>framework:
+    # ...
+    templating:
+        engines: ['twig']</>
+
+  * Then <fg=blue>add</> the following to config/routes.yaml:
+
+<fg=blue>dtc_grid:</>
+    <fg=blue>resource: '@DtcGridBundle/Resources/config/routing.yml'</>

--- a/mmucklo/grid-bundle/4.0/post-install.txt
+++ b/mmucklo/grid-bundle/4.0/post-install.txt
@@ -2,16 +2,16 @@
 <bg=blue;fg=white> What's next? </>
 <bg=blue;fg=white>              </>
 
-  * <fg=orange>Warning:</> make sure the twig engine is turned on in framework.yaml
+  * <bg=black;fg=orange>Warning:</> make sure the twig engine is turned on in framework.yaml
 
-    - If not, <fg=blue>add</> the following to config/packages/framework.yaml:
+    - If not, <bg=black;fg=blue>add</> the following to config/packages/framework.yaml:
 
-<fg=blue>framework:
+<bg=black;fg=blue>framework:
     # ...
     templating:
         engines: ['twig']</>
 
-  * Then <fg=blue>add</> the following to config/routes.yaml:
+  * Then <bg=black;fg=blue>add</> the following to config/routes.yaml:
 
-<fg=blue>dtc_grid:</>
-    <fg=blue>resource: '@DtcGridBundle/Resources/config/routing.yml'</>
+<bg=black;fg=blue>dtc_grid:</>
+    <bg=black;fg=blue>resource: '@DtcGridBundle/Resources/config/routing.yml'</>

--- a/mmucklo/grid-bundle/4.0/post-install.txt
+++ b/mmucklo/grid-bundle/4.0/post-install.txt
@@ -2,16 +2,11 @@
 <bg=blue;fg=white> What's next? </>
 <bg=blue;fg=white>              </>
 
-  * <bg=black;fg=orange>Warning:</> make sure the twig engine is turned on in framework.yaml
+  * Warning: make sure the twig engine is turned on in framework.yaml
 
-    - If not, <bg=black;fg=blue>add</> the following to config/packages/framework.yaml:
+    - If not, add the following to config/packages/framework.yaml:
 
-<bg=black;fg=blue>framework:
+framework:
     # ...
     templating:
-        engines: ['twig']</>
-
-  * Then <bg=black;fg=blue>add</> the following to config/routes.yaml:
-
-<bg=black;fg=blue>dtc_grid:</>
-    <bg=black;fg=blue>resource: '@DtcGridBundle/Resources/config/routing.yml'</>
+        engines: ['twig']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This pull request adds a recipe for DtcGridBundle which has been updated to support Symfony 4.

Former PR #186 

DtcGridBundle as of version 4.0.3 should now install cleanly on a fresh Symfony 4 installation.