### PR TITLE
Add alias to SentryBundle

### DIFF
--- a/sentry/sentry-symfony/1.0/manifest.json
+++ b/sentry/sentry-symfony/1.0/manifest.json
@@ -1,4 +1,5 @@
 {
+    "aliases": ["sentry"],
     "bundles": {
         "Sentry\\SentryBundle\\SentryBundle": ["all"]
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Adding the `sentry` alias to the SentryBundle.