### PR TITLE
Fix path to the src/ directory: root_dir -> project_dir

### DIFF
--- a/php-translation/symfony-bundle/0.4/config/packages/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.4/config/packages/php_translation.yaml
@@ -5,7 +5,7 @@ translation:
         config_name: app
     configs:
         app:
-            dirs: ["%kernel.project_dir%/templates", "%kernel.root_dir%/src"]
+            dirs: ["%kernel.project_dir%/templates", "%kernel.project_dir%/src"]
             output_dir: "%kernel.project_dir%/translations"
             excluded_names: ["*TestCase.php", "*Test.php"]
             excluded_dirs: [cache, data, logs]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Got the next error about invalid path:
```text
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In BaseNode.php line 348:
!!
!!    Invalid configuration for path "translation.configs.app.dirs.1": The direct
!!    ory "/Users/victor/www/symfony/src/src" does not exist.
!!
!!
!!  In Configuration.php line 127:
!!
!!    The directory "/Users/victor/www/symfony/src/src" does n
!!    ot exist.
```