### PR TITLE
QandidateToggleBundle: do not enable SecurityBundle

### DIFF
--- a/qandidate/toggle-bundle/1.0/manifest.json
+++ b/qandidate/toggle-bundle/1.0/manifest.json
@@ -1,6 +1,5 @@
 {
     "bundles": {
-        "Symfony\\Bundle\\SecurityBundle\\SecurityBundle": ["all"],
         "Qandidate\\Bundle\\ToggleBundle\\QandidateToggleBundle": ["all"]
     },
     "copy-from-recipe": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

I thought it would be a good idea to also enable the SecurityBundle because it's a dependency for the QandidateToggleBundle. However when removing the QandidateToggleBundle this recipe also unregisters the SecurityBundle. 