### PR TITLE
Add Enqueue job queue pack

### DIFF
--- a/enqueue/job-queue-pack/0.8/etc/packages/enqueue-job-queue.yaml
+++ b/enqueue/job-queue-pack/0.8/etc/packages/enqueue-job-queue.yaml
@@ -1,0 +1,11 @@
+enqueue:
+    job: true
+
+doctrine:
+    orm:
+        mappings:
+            EnqueueJobQueue:
+                is_bundle: false
+                type: xml
+                dir: '%kernel.project_dir%/vendor/enqueue/job-queue/Doctrine/mapping'
+                prefix: 'Enqueue\JobQueue\Doctrine\Entity'

--- a/enqueue/job-queue-pack/0.8/manifest.json
+++ b/enqueue/job-queue-pack/0.8/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-recipe": {
+        "etc/": "%ETC_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

A pack to install Enqueue's job queue with Doctrine ORM as a storage in a Symfony Flex application