### PR TITLE
Fix Github\Client calls configuration

### DIFF
--- a/knplabs/github-api/2.6/config/packages/github_api.yaml
+++ b/knplabs/github-api/2.6/config/packages/github_api.yaml
@@ -2,4 +2,5 @@ services:
     Github\Client:
         class: Github\Client
         # Uncomment to enable authentication
-        #calls: ['authenticate', ['%env(GITHUB_USERNAME)%', '%env(GITHUB_SECRET)%', '%env(GITHUB_AUTH_METHOD)%']]
+        #calls:
+        #    - ['authenticate', ['%env(GITHUB_USERNAME)%', '%env(GITHUB_SECRET)%', '%env(GITHUB_AUTH_METHOD)%']]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Fix the YAML configuration for `Github\Client` calls. Use this way, this will trigger an error:
> Type error: Argument 2 passed to Symfony\Component\DependencyInjection\Definition::addMethodCall() must be of the type array, string given
