### PR TITLE
Introduce algolia/search-bundle v3

### DIFF
--- a/algolia/search-bundle/3.0/config/packages/algolia_search.yaml
+++ b/algolia/search-bundle/3.0/config/packages/algolia_search.yaml
@@ -1,0 +1,4 @@
+# All available configuration can be found here:
+# https://www.algolia.com/doc/api-client/symfony/configuration/
+algolia_search:
+    prefix: '%env(APP_ENV)%_'

--- a/algolia/search-bundle/3.0/manifest.json
+++ b/algolia/search-bundle/3.0/manifest.json
@@ -1,0 +1,14 @@
+{
+    "bundles": {
+        "Algolia\\SearchBundle\\AlgoliaSearchBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#1": "Create a free account on www.algolia.com",
+        "#2": "and get your credentials from the API Keys tab.",
+        "ALGOLIA_APP_ID": "...",
+        "ALGOLIA_API_KEY": "..."
+    }
+}

--- a/algolia/search-bundle/3.0/post-install.txt
+++ b/algolia/search-bundle/3.0/post-install.txt
@@ -1,0 +1,12 @@
+<bg=blue;fg=white>                                  </>
+<bg=blue;fg=white> Next: SearchBundle Configuration </>
+<bg=blue;fg=white>                                  </>
+
+  * The Algolia/SearchBundle uses Algolia by default. Create a free
+    account on http://www.algolia.com and modify your ALGOLIA_APP_ID
+    and ALGOLIA_API_KEY config in <fg=green>.env</>
+
+  * Edit the configuration in <fg=green>config/packages/algolia_search.yaml</>
+    to start indexing your data.
+
+Documentation: https://www.algolia.com/doc/api-client/symfony/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

There is already a recipe for the Algolia Search Bundle and I have just released the version 3.0. Version 2 will be maintained (patch-only) but should not be installed for new projects.

This version introduce many new features but mostly:

* **Simple**: You can get started with only 5 lines of YAML
* **Extensible**: It let’s you easily replace services by implementing Interfaces
* **Standard**: It leverages `Normalizers` to convert entities for indexing
* **Dev-friendly**: It lets you disable HTTP calls easily (while running tests for examples)
* **Futur-ready**: It let’s you unsubscribe from doctrine events easily to use a messaging/queue system.

Documentation can be found [here](http://www.algolia.com/doc/api-client/symfony/) or in the [README](https://github.com/algolia/search-bundle/blob/master/README.md).

Any feedback is very welcomed 😃 
