### PR TITLE
Fix sonata-project/core-bundle config

### DIFF
--- a/sonata-project/core-bundle/3.9/config/packages/sonata_core.yaml
+++ b/sonata-project/core-bundle/3.9/config/packages/sonata_core.yaml
@@ -1,5 +1,4 @@
 sonata_core:
-    flashmessage: {}
     form:
         mapping:
             enabled: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Configuration file must be inside `config/packages` directory, not in `config/packages/sonata_project`.

With this PR i moved `config/packages/sonata_project/sonata_core.yaml` file to `config/packages/` and removed redundant parameter.

Travis was green in https://github.com/symfony/recipes-contrib/pull/240, because `sonata-project/core-bundle` does not need any additional configuration