### PR TITLE
Change manifest to install CKEditor Scripts by default.

### DIFF
--- a/hillrange/ckeditor/0.1/manifest.json
+++ b/hillrange/ckeditor/0.1/manifest.json
@@ -6,6 +6,6 @@
         "config/": "%CONFIG_DIR%/"
     },
     "composer-scripts": {
-        "ckeditor:install": "symfony-cmd"
+        "ckeditor:install --clear=drop": "symfony-cmd"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Add default option for install of CKEditor Scripts.
