### PR TITLE
Update nelmio_api_doc.yaml

### DIFF
--- a/nelmio/api-doc-bundle/3.0/config/packages/nelmio_api_doc.yaml
+++ b/nelmio/api-doc-bundle/3.0/config/packages/nelmio_api_doc.yaml
@@ -4,6 +4,6 @@ nelmio_api_doc:
             title: My App
             description: This is an awesome app!
             version: 1.0.0
-    routes: # to filter documented routes
+    areas: # to filter documented areas
         path_patterns:
             - ^/api(?!/doc$) # Accepts routes under /api except /api/doc


### PR DESCRIPTION
In Symfony 4
The `nelmio_api_doc.routes` config option is deprecated. Please use `nelmio_api_doc.areas` instead (just replace `routes` by `areas` in your config)

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
