### PR TITLE
[MsgPhpUserBundle] enable doctrine mapping

### DIFF
--- a/msgphp/user-bundle/0.2/src/Entity/User/User.php
+++ b/msgphp/user-bundle/0.2/src/Entity/User/User.php
@@ -2,11 +2,12 @@
 
 namespace App\Entity\User;
 
+use Doctrine\ORM\Mapping as ORM;
 use MsgPhp\User\Entity\User as BaseUser;
 use MsgPhp\User\UserIdInterface;
 
 /**
- * @final
+ * @ORM\Entity()
  */
 class User extends BaseUser
 {

--- a/msgphp/user-bundle/0.2/src/Entity/User/User.php
+++ b/msgphp/user-bundle/0.2/src/Entity/User/User.php
@@ -11,6 +11,7 @@ use MsgPhp\User\UserIdInterface;
  */
 class User extends BaseUser
 {
+    /** @ORM\Id() @ORM\Column(type="msgphp_user_id") */
     private $id;
 
     public function __construct(UserIdInterface $id)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Looking at some other entity-providing bundles..., they all do this: enable doctrine mapping by default. It doesnt break without doctrine (it's metadata-ish).. so seems a good DX improvement :)