### PR TITLE
Fix RedisBundle recipe to always work out of the box

### DIFF
--- a/snc/redis-bundle/2.0/config/packages/snc_redis.yaml
+++ b/snc/redis-bundle/2.0/config/packages/snc_redis.yaml
@@ -1,6 +1,12 @@
 snc_redis:
     clients:
-        default:
-            type: predis
-            alias: default
-            dsn: "%env(REDIS_URL)%"
+
+# Define your clients here. The example below connects to database 0 of the default Redis server.
+#
+# See https://github.com/snc/SncRedisBundle/blob/master/Resources/doc/index.md for instructions on
+# how to configure the bundle.
+#
+#        default:
+#            type: predis
+#            alias: default
+#            dsn: "%env(REDIS_URL)%"


### PR DESCRIPTION
The recipe should not be opinionated about using phpredis or predis as the bundle supports both.

Fixes #335

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
