### PR TITLE
Make the nelmio/api-doc-bundle recipe works out of the box

### DIFF
--- a/nelmio/api-doc-bundle/3.0/config/routes/nelmio_api_doc.yaml
+++ b/nelmio/api-doc-bundle/3.0/config/routes/nelmio_api_doc.yaml
@@ -1,11 +1,12 @@
-# Requires the Asset component and the Twig bundle
-app.swagger_ui:
-    path: /api/doc
+# Expose your documentation as JSON swagger compliant
+app.swagger:
+    path: /api/doc.json
     methods: GET
-    defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+    defaults: { _controller: nelmio_api_doc.controller.swagger }
 
-# To expose your documentation as JSON
-#app.swagger:
-#    path: /api/doc.json
+## Requires the Asset component and the Twig bundle
+## $ composer require composer require twig asset
+#app.swagger_ui:
+#    path: /api/doc
 #    methods: GET
-#    defaults: { _controller: nelmio_api_doc.controller.swagger }
+#    defaults: { _controller: nelmio_api_doc.controller.swagger_ui }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

After applying this recipe, the route "/api/doc" was loaded by default, but it requires two component (`asset` and `twig`) that are usually not require for API only project.

The json route works of the box so it can be provided without additional action.

I faced it and it felt strange, and it seems that others have too : https://github.com/nelmio/NelmioApiDocBundle/issues/1220

