### PR TITLE
 [MsgPhpEavBundle] Add ORM GeneratedValue annotation

### DIFF
--- a/msgphp/eav-bundle/0.2/src/Entity/Eav/Attribute.php
+++ b/msgphp/eav-bundle/0.2/src/Entity/Eav/Attribute.php
@@ -11,7 +11,7 @@ use MsgPhp\Eav\Entity\Attribute as BaseAttribute;
  */
 class Attribute extends BaseAttribute
 {
-    /** @ORM\Id() @ORM\Column(type="msgphp_attribute_id") */
+    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_attribute_id") */
     private $id;
 
     public function __construct(AttributeIdInterface $id)

--- a/msgphp/eav-bundle/0.2/src/Entity/Eav/AttributeValue.php
+++ b/msgphp/eav-bundle/0.2/src/Entity/Eav/AttributeValue.php
@@ -11,7 +11,7 @@ use MsgPhp\Eav\Entity\AttributeValue as BaseAttributeValue;
  */
 class AttributeValue extends BaseAttributeValue
 {
-    /** @ORM\Id() @ORM\Column(type="msgphp_attribute_value_id") */
+    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_attribute_value_id") */
     private $id;
 
     public function __construct(AttributeValueIdInterface $id, Attribute $attribute, $value)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

`msgphp_*_id` resolves to integer by default, so adding `@ORM\GeneratedValue()` seems a good DX improvement. At least it's more obvious to remove then to add.