### PR TITLE
[Sentry Bundle] Make config easier to use and deploy-friendly

### DIFF
--- a/sentry/sentry-symfony/1.0/config/packages/prod/sentry.yaml
+++ b/sentry/sentry-symfony/1.0/config/packages/prod/sentry.yaml
@@ -1,2 +1,0 @@
-sentry:
-    dsn: '%env(SENTRY_DSN)%'

--- a/sentry/sentry-symfony/1.0/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/1.0/config/packages/sentry.yaml
@@ -5,7 +5,6 @@ parameters:
     env(SENTRY_DSN): ''
 
 sentry:
-    # Remove the `resolve:` operator if you are using Symfony 3.3
     dsn: '%env(resolve:SENTRY_DSN)%'
 
     options:

--- a/sentry/sentry-symfony/1.0/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/1.0/config/packages/sentry.yaml
@@ -1,4 +1,13 @@
+parameters:
+    # Add a fallback SENTRY_DSN if the env var is not set. This allows you to
+    # run cache:warmup even if your environment variables are not available yet.
+    # You should not need to change this value.
+    env(SENTRY_DSN): ''
+
 sentry:
+    # Remove the `resolve:` operator if you are using Symfony 3.3
+    dsn: '%env(resolve:SENTRY_DSN)%'
+
     options:
         curl_method: async
 


### PR DESCRIPTION
I made a few changes to the config to remove some frustrations that I encountered while developing and deploying. They were inspired by the [Doctrine recipe](https://github.com/symfony/recipes/blob/d72de5d0f6e3e8ded234d720399d5cbdf080a604/doctrine/doctrine-bundle/1.6/config/packages/doctrine.yaml):

* Set a default value for the SENTRY_DSN env var to prevent errors during deployment when running commands like cache:warmup
* Merge config/packages/prod/sentry.yaml into config/packages/sentry.yaml for simplicity. I do not see a reason for separating them by default

Sentry will be enabled in any environment where a non-blank SENTRY_DSN env var is provided. Not setting the var or having it set to an empty string will disable Sentry error handling

@ruudk pinging you since you are the maintainer

| Q             | A
| ------------- | ---
| License       | MIT