### PR TITLE
TDBM: Removing commented options and adding a link to the documentation

### DIFF
--- a/thecodingmachine/tdbm-bundle/5.0/config/packages/tdbm.yaml
+++ b/thecodingmachine/tdbm-bundle/5.0/config/packages/tdbm.yaml
@@ -1,18 +1,4 @@
+# Read more about TDBM available options at: https://thecodingmachine.github.io/tdbm/doc/install_symfony.html
 tdbm:
     bean_namespace: App\Beans
     dao_namespace: App\Daos
-
-## Uncomment the naming section if you want to customize the names of the generated classes / beans
-#    naming:
-#        bean_prefix: ""
-#        bean_suffix: ""
-#        base_bean_prefix: Abstract
-#        base_bean_suffix: ""
-#        dao_prefix: ""
-#        dao_suffix: Dao
-#        base_dao_prefix: Abstract
-#        base_dao_suffix: Dao
-## Exceptions are used to transform a table name (the key) into a bean name (the value)
-## Very useful if your database table names are not in english (as TDBM will try to turn plural table names into singular bean names)
-#        exceptions:
-#            chevaux: Cheval


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

@Nyholm  TDBM PR was fixed before all comments were taken into account. See #361 .

This PR removes commented configuration settings and adds a link to the documentation instead.