### PR TITLE
Fix symfony-cmf/cmf-phpcr-dbal-pack recipe

### DIFF
--- a/symfony-cmf/cmf-phpcr-dbal-pack/1.0/manifest.json
+++ b/symfony-cmf/cmf-phpcr-dbal-pack/1.0/manifest.json
@@ -1,11 +1,4 @@
 {
-    "bundles": {
-        "Symfony\\Cmf\\Bundle\\RoutingBundle\\CmfRoutingBundle": ["all"],
-        "Symfony\\Cmf\\Bundle\\MenuBundle\\CmfMenuBundle": ["all"],
-        "Symfony\\Cmf\\Bundle\\CoreBundle\\CmfCoreBundle": ["all"],
-        "Symfony\\Cmf\\Bundle\\ContentBundle\\CmfContentBundle": ["all"],
-        "Symfony\\Cmf\\Bundle\\BlockBundle\\CmfBlockBundle": ["all"]
-    },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR removes `bundles` section of manifest.json file for `symfony-cmf/cmf-phpcr-dbal-pack recipe`, because a package is a `pack` and all bundles will be registered automaticaly without that section.