### PR TITLE
Add --ignore-platform-reqs option to composer require command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ install:
     - composer config extra.symfony.allow-contrib true
 
 script:
-    - composer req "${PACKAGES}"
+    - composer req --ignore-platform-reqs "${PACKAGES}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

With this PR will `composer req` command will ignore `php`, `hhvm`, `lib-*` and `ext-*` requirements and force the installation.

This is helpful for testing recipes of packages, that provide platform via their dependencies. For example, [sonata-project/media-odm-pack](https://packagist.org/packages/sonata-project/media-odm-pack) depends on [alcaeus/mongo-php-adapter](https://packagist.org/packages/alcaeus/mongo-php-adapter), which provides `ext-mongo`. `sonata-project/media-odm-pack` cannot be installed just with `composer require sonata-project/media-odm-pack`, only after executing after `composer config platform.ext-mongo 1.6.16`

See also https://github.com/composer/composer/issues/5030, a similar issue was described there 2 years ago (and it won't be solved, i guess)