### PR TITLE
Add sonata-project/media-odm-pack recipe

### DIFF
--- a/sonata-project/media-odm-pack/1.0/config/packages/sonata_media_odm.yaml
+++ b/sonata-project/media-odm-pack/1.0/config/packages/sonata_media_odm.yaml
@@ -1,0 +1,6 @@
+sonata_media:
+    class:
+        media: App\Document\SonataMediaMedia
+        gallery: App\Document\SonataMediaGallery
+        gallery_has_media: App\Document\SonataMediaGalleryHasMedia
+    db_driver: doctrine_mongodb

--- a/sonata-project/media-odm-pack/1.0/manifest.json
+++ b/sonata-project/media-odm-pack/1.0/manifest.json
@@ -1,0 +1,6 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    }
+}

--- a/sonata-project/media-odm-pack/1.0/src/Document/SonataMediaGallery.php
+++ b/sonata-project/media-odm-pack/1.0/src/Document/SonataMediaGallery.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+use JMS\Serializer\Annotation as Serializer;
+use Sonata\MediaBundle\Document\BaseGallery;
+
+/**
+ * @MongoDB\Document
+ * @MongoDB\HasLifecycleCallbacks
+ */
+class SonataMediaGallery extends BaseGallery
+{
+    /**
+     * @MongoDB\Id()
+     * @Serializer\Groups(groups={"sonata_api_read", "sonata_api_write", "sonata_search"})
+     */
+    protected $id;
+
+    /**
+     * @MongoDB\ReferenceMany(
+     *     targetDocument="App\Document\SonataMediaGalleryHasMedia",
+     *     mappedBy="gallery", cascade={"persist"}, orphanRemoval=false, sort={"position" = "ASC"}
+     * )
+     */
+    protected $galleryHasMedias;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @MongoDB\PrePersist
+     */
+    public function prePersist(): void
+    {
+        parent::prePersist();
+    }
+
+    /**
+     * @MongoDB\PreUpdate
+     */
+    public function preUpdate(): void
+    {
+        parent::preUpdate();
+    }
+}

--- a/sonata-project/media-odm-pack/1.0/src/Document/SonataMediaGalleryHasMedia.php
+++ b/sonata-project/media-odm-pack/1.0/src/Document/SonataMediaGalleryHasMedia.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+use JMS\Serializer\Annotation as Serializer;
+use Sonata\MediaBundle\Document\BaseGalleryHasMedia;
+
+/**
+ * @MongoDB\Document
+ * @MongoDB\HasLifecycleCallbacks
+ */
+class SonataMediaGalleryHasMedia extends BaseGalleryHasMedia
+{
+    /**
+     * @MongoDB\Id()
+     * @Serializer\Groups(groups={"sonata_api_read", "sonata_api_write", "sonata_search"})
+     */
+    protected $id;
+
+    /**
+     * @MongoDB\ReferenceOne(
+     *     targetDocument="App\Document\SonataMediaMedia",
+     *     inversedBy="galleryHasMedias", cascade={"persist"}
+     * )
+     */
+    protected $media;
+
+    /**
+     * @MongoDB\ReferenceOne(
+     *     targetDocument="App\Document\SonataMediaGallery",
+     *     inversedBy="galleryHasMedias", cascade={"persist"}
+     * )
+     */
+    protected $gallery;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @MongoDB\PrePersist
+     */
+    public function prePersist(): void
+    {
+        parent::prePersist();
+    }
+
+    /**
+     * @MongoDB\PreUpdate
+     */
+    public function preUpdate(): void
+    {
+        parent::preUpdate();
+    }
+}

--- a/sonata-project/media-odm-pack/1.0/src/Document/SonataMediaMedia.php
+++ b/sonata-project/media-odm-pack/1.0/src/Document/SonataMediaMedia.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as MongoDB;
+use JMS\Serializer\Annotation as Serializer;
+use Sonata\MediaBundle\Document\BaseMedia;
+
+/**
+ * @MongoDB\Document
+ * @MongoDB\HasLifecycleCallbacks
+ */
+class SonataMediaMedia extends BaseMedia
+{
+    /**
+     * @MongoDB\Id()
+     * @Serializer\Groups(groups={"sonata_api_read", "sonata_api_write", "sonata_search"})
+     */
+    protected $id;
+
+    /**
+     * @MongoDB\ReferenceMany(
+     *     targetDocument="App\Document\SonataMediaGalleryHasMedia",
+     *     mappedBy="media", cascade={"persist"}, orphanRemoval=false, sort={"position" = "ASC"}
+     * )
+     */
+    protected $galleryHasMedias;
+
+    /**
+     * @MongoDB\Field(type="string", nullable=true)
+     */
+    protected $authorName;
+
+    /**
+     * @MongoDB\Field(type="boolean", nullable=true)
+     */
+    protected $cdnIsFlushable;
+
+    /**
+     * @MongoDB\Field(type="string", nullable=true)
+     */
+    protected $description;
+
+    /**
+     * @MongoDB\Field(type="string", nullable=true)
+     */
+    protected $copyright;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @MongoDB\PrePersist
+     */
+    public function prePersist(): void
+    {
+        parent::prePersist();
+    }
+
+    /**
+     * @MongoDB\PreUpdate
+     */
+    public function preUpdate(): void
+    {
+        parent::preUpdate();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

To test a recipe execute following commands:
```bash
composer create-project symfony/skeleton .
composer config extra.symfony.allow-contrib true
export SYMFONY_ENDPOINT=https://symfony.sh/r/github.com/symfony/recipes-contrib/410
composer config platform.ext-mongo 1.6.16
composer require sonata-project/media-odm-pack
```

Create `docker-compose.yaml`
```yaml
version: '3.4'

services:
    mongo:
        image: mongo:3.6
        ports:
            - "27017:27017"
        environment:
            MONGO_DATA_DIR: /data/db
        volumes:
          - database:/data/db

volumes:
    database:
```

Execute commands:
```bash
docker-compose up -d
bin/console doctrine:mongodb:schema:create
php -S 127.0.0.1:80 -t public
```

Under Windows (for Docker Toolbox) update `.env` file: change `localhost` in `MONGODB_URL=mongodb://localhost:27017` to a IP from `docker-machine env` output

Visit http://localhost/admin/
