### PR TITLE
Add LiipImagineBundle's cache folder to .gitignore

### DIFF
--- a/liip/imagine-bundle/1.8/manifest.json
+++ b/liip/imagine-bundle/1.8/manifest.json
@@ -4,5 +4,8 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    }
+    },
+    "gitignore": [
+        "/public/media/cache/"
+    ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
