### PR TITLE
Add a recipe for dunglas/doctrine-json-odm

### DIFF
--- a/dunglas/doctrine-json-odm/0.1/manifest.json
+++ b/dunglas/doctrine-json-odm/0.1/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Dunglas\\DoctrineJsonOdm\\Bundle\\DunglasDoctrineJsonOdmBundle": ["all"]
+    }
+}

--- a/dunglas/doctrine-json-odm/0.1/post-install.txt
+++ b/dunglas/doctrine-json-odm/0.1/post-install.txt
@@ -1,6 +1,0 @@
-<bg=blue;fg=white>              </>
-<bg=blue;fg=white> What's next? </>
-<bg=blue;fg=white>              </>
-
-  * The <comment>json_document</> column type is now available
-  * Go to https://github.com/dunglas/doctrine-json-odm for examples and docs

--- a/dunglas/doctrine-json-odm/0.1/post-install.txt
+++ b/dunglas/doctrine-json-odm/0.1/post-install.txt
@@ -1,0 +1,6 @@
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> What's next? </>
+<bg=blue;fg=white>              </>
+
+  * The <comment>json_document</> column type is now available
+  * Go to https://github.com/dunglas/doctrine-json-odm for examples and docs


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

https://github.com/dunglas/doctrine-json-odm
A recipe is mandatory because the bundle is provided in the library, thus cannot be auto-discovered by Flex.