### PR TITLE
Fixes typo in symfony-cmf/cmf-phpcr-dbal-pack

### DIFF
--- a/symfony-cmf/cmf-phpcr-dbal-pack/1.0/config/packages/cmf_phpcr_dbal.yaml
+++ b/symfony-cmf/cmf-phpcr-dbal-pack/1.0/config/packages/cmf_phpcr_dbal.yaml
@@ -10,7 +10,7 @@ cmf_routing:
     chain:
         routers_by_id:
             cmf_routing.dynamic_router: 200
-            routder.default:             100
+            router.default:             100
 
 cmf_core:
     # content-bundle, menu-bundle, block-bundle and routing-bundle will get same persistence configduration as core


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Changed `routder` to `router`; this should fix an error while installing:

```  - Configuring symfony-cmf/cmf-phpcr-dbal-pack (>=1.0): From github.com/symfony/recipes-contrib:master
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!
!!  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 31:
!!
!!    The service "router" has a dependency on a non-existent service "routder.de
!!    fault".
```