### PR TITLE
updating msgphp user receipt for mysql/maria db as well as msgphp pull 214

### DIFF
--- a/msgphp/eav-bundle/0.2/src/Entity/Eav/Attribute.php
+++ b/msgphp/eav-bundle/0.2/src/Entity/Eav/Attribute.php
@@ -11,7 +11,7 @@ use MsgPhp\Eav\Entity\Attribute as BaseAttribute;
  */
 class Attribute extends BaseAttribute
 {
-    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_attribute_id") */
+    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_attribute_id", length=191) */
     private $id;
 
     public function __construct(AttributeIdInterface $id)

--- a/msgphp/eav-bundle/0.2/src/Entity/Eav/AttributeValue.php
+++ b/msgphp/eav-bundle/0.2/src/Entity/Eav/AttributeValue.php
@@ -11,7 +11,7 @@ use MsgPhp\Eav\Entity\AttributeValue as BaseAttributeValue;
  */
 class AttributeValue extends BaseAttributeValue
 {
-    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_attribute_value_id") */
+    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_attribute_value_id", length=191) */
     private $id;
 
     public function __construct(AttributeValueIdInterface $id, Attribute $attribute, $value)

--- a/msgphp/user-bundle/0.6/src/Entity/User/User.php
+++ b/msgphp/user-bundle/0.6/src/Entity/User/User.php
@@ -11,7 +11,7 @@ use MsgPhp\User\UserIdInterface;
  */
 class User extends BaseUser
 {
-    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_user_id") */
+    /** @ORM\Id() @ORM\GeneratedValue() @ORM\Column(type="msgphp_user_id", length=191) */
     private $id;
 
     public function __construct(UserIdInterface $id)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Key columns only support a max length of 191 characters in mysql/maria db on default, using the `utf8mb4` charset and `utf8mb4_unicode_ci` collate.

This change ensures that msgphp user bundle will work out of the box as well as prepare for https://github.com/msgphp/msgphp/pull/214