### PR TITLE
Offer default \App\Document\ resolution

### DIFF
--- a/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/doctrine_phpcr_dbal.yaml
+++ b/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/doctrine_phpcr_dbal.yaml
@@ -16,6 +16,15 @@ doctrine_phpcr:
     odm:
         auto_mapping: true
         auto_generate_proxy_classes: true
+        mappings:
+            # offer default resolution of "App\Document\". For more details, see: https://symfony.com/doc/current/cmf/bundles/phpcr_odm/introduction.html#doctrine-phpcr-odm-configuration
+            App:
+                mapping: true
+                type: annotation
+                dir: '%kernel.root_dir%/Document'
+                alias: App
+                prefix: App\Document\
+                is_bundle: false
         # add your locale configuration here as described in: https://symfony.com/doc/current/cmf/bundles/phpcr_odm/multilang.html#translation-configuration
 doctrine_cache:
     providers:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

As part of the solution in https://github.com/doctrine/DoctrinePHPCRBundle/pull/330, offer recipe based `App\Document` resolution.
