### PR TITLE
Fix the travis build when changing multiple recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ install:
     - composer config extra.symfony.allow-contrib true
 
 script:
-    - composer req --ignore-platform-reqs "${PACKAGES}"
+    - composer req --ignore-platform-reqs $(echo $PACKAGES)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The different packages need to be passed as separate arguments to `composer require`
#SymfonyConHackday2018