### PR TITLE
Adding Graphqlite bundle

### DIFF
--- a/thecodingmachine/graphqlite-bundle/3.0/config/packages/graphqlite.yaml
+++ b/thecodingmachine/graphqlite-bundle/3.0/config/packages/graphqlite.yaml
@@ -1,4 +1,4 @@
-# Read more about Graphqlite available options at: https://graphqlite.thecodingmachine.io/docs/symfony-bundle
+# Read more about GraphQLite available options at: https://graphqlite.thecodingmachine.io/docs/symfony-bundle
 graphqlite:
     namespace:
         controllers: App\Controller\

--- a/thecodingmachine/graphqlite-bundle/3.0/config/packages/graphqlite.yaml
+++ b/thecodingmachine/graphqlite-bundle/3.0/config/packages/graphqlite.yaml
@@ -1,0 +1,16 @@
+# Read more about Graphqlite available options at: https://graphqlite.thecodingmachine.io/docs/symfony-bundle
+graphqlite:
+    namespace:
+        controllers: App\Controller\
+        types:
+            - App\
+    debug:
+        # Include exception messages in output when an error arises
+        INCLUDE_DEBUG_MESSAGE: false
+        # Include stacktrace in output when an error arises
+        INCLUDE_TRACE: false
+        # Exceptions are not caught by the engine and propagated to Symfony
+        RETHROW_INTERNAL_EXCEPTIONS: false
+        # Exceptions that do not implement ClientAware interface are
+        # not caught by the engine and propagated to Symfony.
+        RETHROW_UNSAFE_EXCEPTIONS: true

--- a/thecodingmachine/graphqlite-bundle/3.0/config/packages/graphqlite.yaml
+++ b/thecodingmachine/graphqlite-bundle/3.0/config/packages/graphqlite.yaml
@@ -4,13 +4,3 @@ graphqlite:
         controllers: App\Controller\
         types:
             - App\
-    debug:
-        # Include exception messages in output when an error arises
-        INCLUDE_DEBUG_MESSAGE: false
-        # Include stacktrace in output when an error arises
-        INCLUDE_TRACE: false
-        # Exceptions are not caught by the engine and propagated to Symfony
-        RETHROW_INTERNAL_EXCEPTIONS: false
-        # Exceptions that do not implement ClientAware interface are
-        # not caught by the engine and propagated to Symfony.
-        RETHROW_UNSAFE_EXCEPTIONS: true

--- a/thecodingmachine/graphqlite-bundle/3.0/manifest.json
+++ b/thecodingmachine/graphqlite-bundle/3.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "TheCodingMachine\\Graphqlite\\Bundle\\GraphqliteBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR adds the Graphqlite bundle to list of recipes.
Graphqlite is a new GraphQL library for PHP that aims at simplifying the use of Webonix/GraphQL.
