### PR TITLE
Add recipe tienvx/mbt-api-bundle

### DIFF
--- a/tienvx/mbt-api-bundle/1.0/config/packages/tienvx_mbt_api.yaml
+++ b/tienvx/mbt-api-bundle/1.0/config/packages/tienvx_mbt_api.yaml
@@ -1,0 +1,4 @@
+tienvx_mbt_api:
+    java_binary: '%env(JAVA_BINARY)%'
+    plantuml_binary: '%env(PLANTUML_BINARY)%'
+    console_binary: '%env(CONSOLE_BINARY)%'

--- a/tienvx/mbt-api-bundle/1.0/config/routes/tienvx_mbt_api.yaml
+++ b/tienvx/mbt-api-bundle/1.0/config/routes/tienvx_mbt_api.yaml
@@ -1,0 +1,3 @@
+tienvx_mbt_api:
+    resource: '@TienvxMbtApiBundle/Resources/config/routing.xml'
+    prefix: '/mbt-api'

--- a/tienvx/mbt-api-bundle/1.0/manifest.json
+++ b/tienvx/mbt-api-bundle/1.0/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "Tienvx\\Bundle\\MbtApiBundle\\TienvxMbtApiBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "JAVA_BINARY": "java",
+        "PLANTUML_BINARY": "plantuml.jar",
+        "CONSOLE_BINARY": "bin/console"
+    }
+}


### PR DESCRIPTION
1. Add recipe for [tienvx/mbt-api-bundle](https://packagist.org/packages/tienvx/mbt-api-bundle)
2. The bundle only support symfony 4.2, so Travis CI build failed for Symfony 3.4, but passed for Symfony 4.2

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
