### PR TITLE
Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)

### DIFF
--- a/nyholm/psr7/1.0/config/packages/nyholm_psr7.yaml
+++ b/nyholm/psr7/1.0/config/packages/nyholm_psr7.yaml
@@ -2,23 +2,13 @@ services:
     _defaults:
         public: false
 
-    ## Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
-    #Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
-    #Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
-    #Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
-    #Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
-    #Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
-    #Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
-
-    ## Register nyholm/psr7 services for autowiring with HTTPlug
-    #Http\Message\MessageFactory: '@nyholm.psr7.httplug_factory'
-    #Http\Message\RequestFactory: '@nyholm.psr7.httplug_factory'
-    #Http\Message\ResponseFactory: '@nyholm.psr7.httplug_factory'
-    #Http\Message\StreamFactory: '@nyholm.psr7.httplug_factory'
-    #Http\Message\UriFactory: '@nyholm.psr7.httplug_factory'
-
-    nyholm.psr7.httplug_factory:
-        class: Nyholm\Psr7\Factory\HttplugFactory
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
 
     nyholm.psr7.psr17_factory:
         class: Nyholm\Psr7\Factory\Psr17Factory


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

HTTPlug factories are deprecated.
And PSR-17 should work out of the box when needed since that's the only sane entry point to PSR-7 world, from DI perspective.

See https://github.com/symfony/recipes-contrib/pull/329#issuecomment-376473240 for past discussion about this.
