### PR TITLE
Add recipe for FOSJSRoutingBundle >2.3, to fix deprecation on Symfony >4.1

### DIFF
--- a/friendsofsymfony/jsrouting-bundle/2.3/config/routes/fos_js_routing.yaml
+++ b/friendsofsymfony/jsrouting-bundle/2.3/config/routes/fos_js_routing.yaml
@@ -1,0 +1,2 @@
+fos_js_routing:
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"

--- a/friendsofsymfony/jsrouting-bundle/2.3/manifest.json
+++ b/friendsofsymfony/jsrouting-bundle/2.3/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "FOS\\JsRoutingBundle\\FOSJsRoutingBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
See https://github.com/FriendsOfSymfony/FOSJsRoutingBundle/issues/327, we added a new routing.xml with the new syntax to keep BC. New installations should automatically use the new xml file which is done in this recipe.

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
