### PR TITLE
Add tienvx/mbt-bundle

### DIFF
--- a/tienvx/mbt-bundle/1.1/manifest.json
+++ b/tienvx/mbt-bundle/1.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Tienvx\\Bundle\\MbtBundle\\TienvxMbtBundle": ["all"]
+    },
+    "container": {
+        "screenshots_dir": "%kernel.project_dir%/var/screenshots"
+    }
+}


### PR DESCRIPTION
1. Add recipe for [tienvx/mbt-bundle](https://packagist.org/packages/tienvx/mbt-bundle)
2. The bundle only support symfony 4.2, so Travis CI build failed for Symfony 3.4, but passed for Symfony 4.2

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
