### PR TITLE
Add gheb/configuration-converter-bundle

### DIFF
--- a/gheb/configuration-converter-bundle/0.5/config/packages/configuration_converter.yaml
+++ b/gheb/configuration-converter-bundle/0.5/config/packages/configuration_converter.yaml
@@ -1,0 +1,2 @@
+#configuration_converter:
+#    api_platform_default_export_path: '%kernel.project_dir%/config/packages/api-platform/' #(default)

--- a/gheb/configuration-converter-bundle/0.5/manifest.json
+++ b/gheb/configuration-converter-bundle/0.5/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Gheb\\ConfigurationConverter\\ConfigurationConverterBundle": ["dev"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/gheb/configuration-converter-bundle/0.5/post-install.txt
+++ b/gheb/configuration-converter-bundle/0.5/post-install.txt
@@ -1,0 +1,9 @@
+<bg=blue;fg=white>                         </>
+<bg=blue;fg=white> Configuration Converter </>
+<bg=blue;fg=white>                         </>
+
+  * Edit the <fg=green>config/packages/configuration_converter.yaml</> file to configure your own settings.
+
+  * Run <fg=green>bin/console configuration:convert</> to convert your configuration.
+
+Documentation: https://github.com/GregoireHebert/configuration-converter-bundle


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Hello good fellows, this PR is part of a bundle that will allow you to switch from annotation configuration to xml or yaml format. At the moment dedicated to api-platform, but will be enlarged to serialization groups and doctrine mapping in the futur.

