### PR TITLE
Create the cms upload folder during install of kunstmaan/media-bundle

### DIFF
--- a/kunstmaan/media-bundle/5.2/manifest.json
+++ b/kunstmaan/media-bundle/5.2/manifest.json
@@ -5,6 +5,10 @@
         ]
     },
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
-    }
+        "config/": "%CONFIG_DIR%/",
+        "public/": "%PUBLIC_DIR%/"
+    },
+    "gitignore": [
+        "/public/uploads/"
+    ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

We use the `public/uploads` directory for all cms uploads. This will make sure the folder is there after install and the content is ignored.