### PR TITLE
Allow to define the default locale as environment variable

### DIFF
--- a/meritoo/common-bundle/0.1/manifest.json
+++ b/meritoo/common-bundle/0.1/manifest.json
@@ -6,6 +6,10 @@
         "config/": "%CONFIG_DIR%/"
     },
     "env": {
+        "MERITOO_DEFAULT_LOCALE": "en",
         "MERITOO_FORM_NOVALIDATE": "false"
+    },
+    "container": {
+        "locale": "%env(MERITOO_DEFAULT_LOCALE)%"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

As mentioned in title, new environment variable that stores default locale