### PR TITLE
[knplabs/github-api] Wire existing HTTPlug factories when possible

### DIFF
--- a/knplabs/github-api/2.6/config/packages/github_api.yaml
+++ b/knplabs/github-api/2.6/config/packages/github_api.yaml
@@ -1,6 +1,13 @@
 services:
     Github\Client:
-        class: Github\Client
+        arguments:
+            - '@Github\HttpClient\Builder'
         # Uncomment to enable authentication
         #calls:
         #    - ['authenticate', ['%env(GITHUB_USERNAME)%', '%env(GITHUB_SECRET)%', '%env(GITHUB_AUTH_METHOD)%']]
+
+    Github\HttpClient\Builder:
+        arguments:
+            - '@?Http\Client\HttpClient'
+            - '@?Http\Message\RequestFactory'
+            - '@?Http\Message\StreamFactory'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Related to https://github.com/symfony/recipes/pull/613 (but not a blocker)

/cc @Nyholm let's use this style as much as possible instead of relying on `Http\Discovery\*`, OK?