### PR TITLE
Fix typos

### DIFF
--- a/misd/phone-number-bundle/1.3/post-install.txt
+++ b/misd/phone-number-bundle/1.3/post-install.txt
@@ -1,8 +1,8 @@
 <bg=green;fg=white></>
-<bg=green;fg=white> You now can use the phone bundle as descriped here: </>
+<bg=green;fg=white> You now can use the phone bundle as described here: </>
 <bg=green;fg=white> https://github.com/misd-service-development/phone-number-bundle#usage </>
 <bg=green;fg=white> The Doctrine configuration has been already done.</>
-<bg=green;fg=white> You now can use `phone_number` as a ORM-Type: </>
+<bg=green;fg=white> You now can use `phone_number` as an ORM-Type: </>
 
   /** @ORM\Column(type="phone_number") */
   private $phoneNumber;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

There were some typos in the post-install output.