### PR TITLE
Add tienvx/mbt-bundle

### DIFF
--- a/tienvx/mbt-bundle/1.7/config/packages/tienvx_mbt.yaml
+++ b/tienvx/mbt-bundle/1.7/config/packages/tienvx_mbt.yaml
@@ -1,0 +1,15 @@
+tienvx_mbt:
+    slack_hook_url: '%env(SLACK_HOOK_URL)%'
+    slack_from: '%env(SLACK_FROM)%'
+    slack_to: '%env(SLACK_TO)%'
+    slack_message: '%env(SLACK_MESSAGE)%'
+    email_from: '%env(EMAIL_FROM)%'
+    email_to: '%env(EMAIL_TO)%'
+    email_subject: '%env(EMAIL_SUBJECT)%'
+
+flysystem:
+    storages:
+        mbt.storage:
+            adapter: 'local'
+            options:
+                directory: "%kernel.project_dir%/var/storage/screenshots"

--- a/tienvx/mbt-bundle/1.7/manifest.json
+++ b/tienvx/mbt-bundle/1.7/manifest.json
@@ -1,0 +1,18 @@
+{
+    "bundles": {
+        "Tienvx\\Bundle\\MbtBundle\\TienvxMbtBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "var/storage/screenshots/": "%VAR_DIR%/storage/screenshots/"
+    },
+    "env": {
+        "SLACK_HOOK_URL": "https://hooks.slack.com/...",
+        "SLACK_FROM": "Example",
+        "SLACK_TO": "#a-channel or @a-person",
+        "SLACK_MESSAGE": "A new bug was found!",
+        "EMAIL_FROM": "from@example.com",
+        "EMAIL_TO": "to@example.com",
+        "EMAIL_SUBJECT": "A new bug was found!"
+    }
+}


### PR DESCRIPTION
1. Add recipe for [tienvx/mbt-bundle](https://packagist.org/packages/tienvx/mbt-bundle)
2. The bundle only support symfony 4.3, so Travis CI build failed for Symfony 3.4, but passed for Symfony 4.3

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
