### PR TITLE
Tweak default cache conf to rely on Symfony Cache and only in prod

### DIFF
--- a/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/doctrine_phpcr_dbal.yaml
+++ b/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/doctrine_phpcr_dbal.yaml
@@ -4,14 +4,13 @@ doctrine_phpcr:
         backend:
             type: doctrinedbal
             connection: default
-            caches:
-                meta: doctrine_cache.providers.phpcr_meta
-                nodes: doctrine_cache.providers.phpcr_nodes
             parameters:
                 jackalope.check_login_on_server: false
         workspace: '%env(PHPCR_WORKSPACE)%'
         username: '%env(PHPCR_USER)%'
         password: '%env(PHPCR_PASSWORD)%'
+        #logging: '%kernel.debug%'
+        #profiling: '%kernel.debug%'
     # enable the ODM layer
     odm:
         auto_mapping: true
@@ -26,9 +25,3 @@ doctrine_phpcr:
                 prefix: App\Document\
                 is_bundle: false
         # add your locale configuration here as described in: https://symfony.com/doc/current/cmf/bundles/phpcr_odm/multilang.html#translation-configuration
-doctrine_cache:
-    providers:
-        phpcr_meta:
-            type: file_system
-        phpcr_nodes:
-            type: file_system

--- a/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/prod/doctrine_phpcr_dbal.yaml
+++ b/doctrine/phpcr-dbal-symfony-pack/1.0/config/packages/prod/doctrine_phpcr_dbal.yaml
@@ -1,0 +1,38 @@
+doctrine_phpcr:
+    odm:
+        auto_generate_proxy_classes: false
+        metadata_cache_driver:
+            type: service
+            id: doctrine_phpcr.system_cache_provider
+    session:
+        backend:
+            caches:
+                meta: doctrine_phpcr.meta_cache_provider
+                nodes: doctrine_phpcr.nodes_cache_provider
+
+services:
+    doctrine_phpcr.meta_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.meta_cache_pool'
+    doctrine_phpcr.nodes_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.nodes_cache_pool'
+    doctrine_phpcr.system_cache_provider:
+        class: Symfony\Component\Cache\DoctrineProvider
+        public: false
+        arguments:
+            - '@doctrine_phpcr.system_cache_pool'
+
+framework:
+    cache:
+        pools:
+            doctrine_phpcr.meta_cache_pool:
+                adapter: cache.app
+            doctrine_phpcr.nodes_cache_pool:
+                adapter: cache.app
+            doctrine_phpcr.system_cache_pool:
+                adapter: cache.system


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Also add cache for metadatas