### PR TITLE
Added rule to rewrite url with encoded anchor

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -53,6 +53,9 @@ DirectoryIndex index.php
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteRule ^ - [L]
 
+    # Rewrites link with anchor
+    RewriteRule ^(.*)#(.*)$ %{REQUEST_URI} [R=301,L,NE]
+
     # Rewrite all other queries to the front controller.
     RewriteRule ^ %{ENV:BASE}/index.php [L]
 </IfModule>


### PR DESCRIPTION
Don't know if it should be included in the recipe but I was fighting to have a rule to rewrite https://example.com%23anchor to https://example.com#anchor so I think it could be

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
