### PR TITLE
Use `default_serializer` instead of `id`

### DIFF
--- a/kunicmarko/jms-messenger-adapter/0.1/config/packages/jms_messenger.yaml
+++ b/kunicmarko/jms-messenger-adapter/0.1/config/packages/jms_messenger.yaml
@@ -4,4 +4,4 @@ framework:
     messenger:
         enabled: true
         serializer:
-            id: messenger.transport.jms_serializer
+            default_serializer: messenger.transport.jms_serializer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Somehow it was wrong,  see docs https://github.com/kunicmarko20/jms-messenger-adapter

/cc @kunicmarko20