### PR TITLE
[apache-pack] fixed serving existing files

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -50,7 +50,7 @@ DirectoryIndex index.php
 
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.
-    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ - [L]
 
     # Rewrite all other queries to the front controller.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

I had problems with the Apache pack when serving existing files, see #737. This PR includes the fix that is working for me.
