### PR TITLE
mmucklo/grid-bundle (5.0): Removed dependency on deprecated twig-engine

### DIFF
--- a/mmucklo/grid-bundle/5.0/config/routes/dtc_grid.yaml
+++ b/mmucklo/grid-bundle/5.0/config/routes/dtc_grid.yaml
@@ -1,0 +1,2 @@
+dtc_grid:
+    resource: '@DtcGridBundle/Resources/config/routing.yml'

--- a/mmucklo/grid-bundle/5.0/manifest.json
+++ b/mmucklo/grid-bundle/5.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Dtc\\GridBundle\\DtcGridBundle": ["all"]
+    },
+    "copy-from-package": {
+        "Resources/config/dtc_grid.yaml": "%CONFIG_DIR%/packages/dtc_grid.yaml"
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

Removes requirement on deprecated twig-engine as of mmucklo/grid-bundle 5.0