### PR TITLE
tienvx/mbt-api-bundle (1.12): Replace java and plantuml by dot

### DIFF
--- a/tienvx/mbt-api-bundle/1.12/config/packages/tienvx_mbt_api.yaml
+++ b/tienvx/mbt-api-bundle/1.12/config/packages/tienvx_mbt_api.yaml
@@ -1,0 +1,3 @@
+tienvx_mbt_api:
+    dot_binary: '%env(DOT_BINARY)%'
+    console_binary: '%env(CONSOLE_BINARY)%'

--- a/tienvx/mbt-api-bundle/1.12/config/routes/tienvx_mbt_api.yaml
+++ b/tienvx/mbt-api-bundle/1.12/config/routes/tienvx_mbt_api.yaml
@@ -1,0 +1,3 @@
+tienvx_mbt_api:
+    resource: '@TienvxMbtApiBundle/Resources/config/routing.xml'
+    prefix: '/mbt-api'

--- a/tienvx/mbt-api-bundle/1.12/manifest.json
+++ b/tienvx/mbt-api-bundle/1.12/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Tienvx\\Bundle\\MbtApiBundle\\TienvxMbtApiBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "DOT_BINARY": "dot",
+        "CONSOLE_BINARY": "bin/console"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This bundle does not work with Symfony 3.x

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
