### PR TITLE
Added some aliases only for faster recipe install

### DIFF
--- a/friendsofsymfony/elastica-bundle/5.0/manifest.json
+++ b/friendsofsymfony/elastica-bundle/5.0/manifest.json
@@ -4,5 +4,6 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    }
+    },
+    "aliases": ["elastica", "elastica-bundle"]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Only adding some aliases for Elastica Bundle recipe, for faster recipe install without knowledge of compelte package path.

Proposed aliases: 
- "elastica" 
- "elasttica-bundle"
