### PR TITLE
Prefer phpredis by default on the recipe

### DIFF
--- a/snc/redis-bundle/2.0/config/packages/snc_redis.yaml
+++ b/snc/redis-bundle/2.0/config/packages/snc_redis.yaml
@@ -7,6 +7,6 @@ snc_redis:
 # how to configure the bundle.
 #
 #        default:
-#            type: predis
+#            type: phpredis
 #            alias: default
 #            dsn: "%env(REDIS_URL)%"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Predis is not maintained anymore
