### PR TITLE
KunstmaanNodeBundle - Enable node locking by default

### DIFF
--- a/kunstmaan/node-bundle/5.2/config/packages/kunstmaan_node.yaml
+++ b/kunstmaan/node-bundle/5.2/config/packages/kunstmaan_node.yaml
@@ -1,0 +1,3 @@
+kunstmaan_node:
+    lock:
+        enabled: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

Enabling node locking is a better and more sensible default config