### PR TITLE
avoid dangerous example config in recipe

### DIFF
--- a/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
+++ b/php-http/httplug-bundle/1.6/config/packages/httplug.yaml
@@ -1,7 +1,7 @@
 httplug:
     plugins:
-        redirect:
-            preserve_header: true
+        retry:
+            retry: 1
 
     discovery:
         client: 'auto'


### PR DESCRIPTION
preserving headers on redirects includes a potential security risk because on redirect to a different domain credential headers would be leaked.

| Q             | A
| ------------- | ---
| License       | MIT

resurrected https://github.com/symfony/recipes/pull/524