### PR TITLE
Mark the misd/phone-number-bundle abandoned

### DIFF
--- a/misd/phone-number-bundle/1.3/config/packages/misd_phone_number.yaml
+++ b/misd/phone-number-bundle/1.3/config/packages/misd_phone_number.yaml
@@ -1,6 +1,6 @@
 # To persist libphonenumber\PhoneNumber objects, add the Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType mapping to your application's config.
 # This requires: doctrine/doctrine-bundle
-doctrine:
-    dbal:
-        types:
-            phone_number: Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType
+# doctrine:
+#     dbal:
+#         types:
+#             phone_number: Misd\PhoneNumberBundle\Doctrine\DBAL\Types\PhoneNumberType

--- a/misd/phone-number-bundle/1.3/post-install.txt
+++ b/misd/phone-number-bundle/1.3/post-install.txt
@@ -1,3 +1,9 @@
+<bg=yellow></>
+<bg=yellow> This bundle is Abandoned: use odolbeau/phone-number-bundle instead </>
+
+  composer remove misd/phone-number-bundle --no-scripts
+  composer require odolbeau/phone-number-bundle
+
 <bg=green;fg=white></>
 <bg=green;fg=white> You now can use the phone bundle as described here: </>
 <bg=green;fg=white> https://github.com/misd-service-development/phone-number-bundle#usage </>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Following https://github.com/misd-service-development/phone-number-bundle/issues/217
This PR adds a warning in the post_install script of `misd/phone-number-bundle` that indicate the package `abandoned`