### PR TITLE
[prooph/event-store] Fix console command

### DIFF
--- a/prooph/event-store-symfony-bundle/0.4/config/packages/prooph_event_store.yaml
+++ b/prooph/event-store-symfony-bundle/0.4/config/packages/prooph_event_store.yaml
@@ -8,3 +8,4 @@ services:
         public: false
 
     Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator: null
+    Prooph\EventStore\EventStore: '@prooph_event_store.default'

--- a/prooph/event-store-symfony-bundle/0.4/src/Command/CreateEventStreamCommand.php
+++ b/prooph/event-store-symfony-bundle/0.4/src/Command/CreateEventStreamCommand.php
@@ -7,22 +7,26 @@ namespace App\Command;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Stream;
 use Prooph\EventStore\StreamName;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class CreateEventStreamCommand extends ContainerAwareCommand
+final class CreateEventStreamCommand extends Command
 {
+    protected static $defaultName = 'event-store:event-stream:create';
+
     private $eventStore;
 
     public function __construct(EventStore $eventStore)
     {
         $this->eventStore = $eventStore;
+
+        parent::__construct(static::$defaultName);
     }
 
     protected function configure()
     {
-        $this->setName('event-store:event-stream:create')
+        $this
             ->setDescription('Create event_stream.')
             ->setHelp('This command creates the event_stream');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

- Fixed parent constructor not called
- Changed parent class from deprecated ContainerAwareCommand to Command
- Make it lazy on 3.4+
