### PR TITLE
Add required parent constructor call.

### DIFF
--- a/prooph/event-store-symfony-bundle/0.4/src/Command/CreateEventStreamCommand.php
+++ b/prooph/event-store-symfony-bundle/0.4/src/Command/CreateEventStreamCommand.php
@@ -18,6 +18,8 @@ final class CreateEventStreamCommand extends ContainerAwareCommand
     public function __construct(EventStore $eventStore)
     {
         $this->eventStore = $eventStore;
+        
+        parent::__construct();        
     }
 
     protected function configure()


### PR DESCRIPTION
As described in the symfony docs `you *must* call the parent constructor`:
https://symfony.com/doc/current/console/commands_as_services.html

Came from:
https://twitter.com/webdevilopers/status/1203757726314184705