### PR TITLE
[prooph/event-store-bus-bridge] Removes incompatible service

### DIFF
--- a/prooph/event-store-bus-bridge/3.1/config/packages/prooph_event_store_bus_bridge.yaml
+++ b/prooph/event-store-bus-bridge/3.1/config/packages/prooph_event_store_bus_bridge.yaml
@@ -7,9 +7,3 @@ services:
             - '@prooph_service_bus.default_event_bus'
         tags:
             - { name: 'prooph_event_store.default.plugin' }
-
-    Prooph\EventStoreBusBridge\TransactionManager:
-        arguments:
-            - '@app.event_store.default'
-        tags:
-            - { name: 'prooph_service_bus.default_command_bus.plugin' }


### PR DESCRIPTION
The TransactionManager service is not compatible with the preconfigured
event store from the prooph/pdo-event-store [flex recipe](https://github.com/symfony/recipes-contrib/blob/master/prooph/pdo-event-store/1.7/config/packages/prooph_pdo_event_store.yaml#L7-L12).

In order to use it, one must first reconfigure the event store
definition to use the PostgresEventStore implementation (instead of the
MySqlEventStore implementation).

See https://github.com/prooph/pdo-event-store/issues/39

| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
