### PR TITLE
PHP-Translations version 0.10.0

### DIFF
--- a/php-translation/symfony-bundle/0.10/config/packages/dev/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.10/config/packages/dev/php_translation.yaml
@@ -1,0 +1,5 @@
+translation:
+    symfony_profiler:
+        enabled: true
+    webui:
+        enabled: true

--- a/php-translation/symfony-bundle/0.10/config/packages/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.10/config/packages/php_translation.yaml
@@ -1,0 +1,11 @@
+translation:
+    locales: ["en"]
+    edit_in_place:
+        enabled: false
+        config_name: app
+    configs:
+        app:
+            dirs: ["%kernel.project_dir%/templates", "%kernel.project_dir%/src"]
+            output_dir: "%kernel.project_dir%/translations"
+            excluded_names: ["*TestCase.php", "*Test.php"]
+            excluded_dirs: [cache, data, logs]

--- a/php-translation/symfony-bundle/0.10/config/routes/dev/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.10/config/routes/dev/php_translation.yaml
@@ -1,0 +1,6 @@
+_translation_webui:
+    resource: "@TranslationBundle/Resources/config/routing_webui.yaml"
+    prefix:  /admin
+  
+_translation_profiler:
+    resource: '@TranslationBundle/Resources/config/routing_symfony_profiler.yaml'

--- a/php-translation/symfony-bundle/0.10/config/routes/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.10/config/routes/php_translation.yaml
@@ -1,0 +1,3 @@
+_translation_edit_in_place:
+    resource: '@TranslationBundle/Resources/config/routing_edit_in_place.yaml'
+    prefix:  /admin

--- a/php-translation/symfony-bundle/0.10/manifest.json
+++ b/php-translation/symfony-bundle/0.10/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Translation\\Bundle\\TranslationBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT


The only change is `.yml` to `.yaml` for the routing files. 