### PR TITLE
updates php-translation/symfony-bundle recipe for version 0.10

### DIFF
--- a/php-translation/symfony-bundle/0.10/config/packages
+++ b/php-translation/symfony-bundle/0.10/config/packages
@@ -1,0 +1,1 @@
+../../0.4/config/packages/

--- a/php-translation/symfony-bundle/0.10/config/routes/dev/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.10/config/routes/dev/php_translation.yaml
@@ -1,0 +1,6 @@
+_translation_webui:
+    resource: "@TranslationBundle/Resources/config/routing_webui.yaml"
+    prefix:  /admin
+  
+_translation_profiler:
+    resource: '@TranslationBundle/Resources/config/routing_symfony_profiler.yaml'

--- a/php-translation/symfony-bundle/0.10/config/routes/php_translation.yaml
+++ b/php-translation/symfony-bundle/0.10/config/routes/php_translation.yaml
@@ -1,0 +1,3 @@
+_translation_edit_in_place:
+    resource: '@TranslationBundle/Resources/config/routing_edit_in_place.yaml'
+    prefix:  /admin

--- a/php-translation/symfony-bundle/0.10/manifest.json
+++ b/php-translation/symfony-bundle/0.10/manifest.json
@@ -1,0 +1,1 @@
+../0.4/manifest.json


### PR DESCRIPTION
This PR updates the recipe for php-translation/symfony-bundle to work for version 0.10
