### PR TITLE
helios-ag/fm-elfinder-bundle : 2 fix

### DIFF
--- a/helios-ag/fm-elfinder-bundle/7.0/config/packages/fm_elfinder.yaml
+++ b/helios-ag/fm-elfinder-bundle/7.0/config/packages/fm_elfinder.yaml
@@ -1,7 +1,6 @@
 fm_elfinder:
     instances:
         default:
-            include_assets: true
             relative_path: true
             connector:
                 roots:

--- a/helios-ag/fm-elfinder-bundle/7.0/config/routes/fm_elfinder.yaml
+++ b/helios-ag/fm-elfinder-bundle/7.0/config/routes/fm_elfinder.yaml
@@ -1,2 +1,2 @@
 fm_elfinder:
-    resource: "@FMElfinderBundle/Resources/config/routing.yml"
+    resource: "@FMElfinderBundle/Resources/config/routing.yaml"


### PR DESCRIPTION
 1- Unrecognized option "include_assets" under "fm_elfinder.instances.default". Available options are "connector", "cors_support", "editor", "editor_template", "fullscreen", "locale", "path_prefix", "relative_path", "theme", "tinymce_popup_path", "visible_mime_types".
**remove the line**

 2-  Unable to find file "@FMElfinderBundle/Resources/config/routing.yml". 
**replace .yml by .yaml**

| Q             | A
| ------------- | ---
| License       | MIT
