### PR TITLE
[symfony/apache-pack] Better FollowSymlinks suggestion

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -9,7 +9,7 @@ DirectoryIndex index.php
 # feature in your server configuration. Uncomment the following line if you
 # install assets as symlinks or if you experience problems related to symlinks
 # when compiling LESS/Sass/CoffeScript assets.
-# Options FollowSymlinks
+# Options +FollowSymlinks
 
 # Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
 # to the front controller "/index.php" but be rewritten to "/index.php/index".


### PR DESCRIPTION
`.htaccess` has a commented out `Options FollowSymlinks` suggestion. When uncommented, it overwrites options defined in any prior `Options` directive (for instance in the main Apache configuration). See [Apache doc](https://httpd.apache.org/docs/current/fr/mod/core.html#options).

I think it should rather be `Options +FollowSymlinks` so that it enables that option without disabling others.

| Q             | A
| ------------- | ---
| License       | MIT
