### PR TITLE
Add tienvx/fos-oauth-server-bundle-orm

### DIFF
--- a/tienvx/fos-oauth-server-bundle-orm/1.0/config/packages/fos_oauth_server_orm.yaml
+++ b/tienvx/fos-oauth-server-bundle-orm/1.0/config/packages/fos_oauth_server_orm.yaml
@@ -1,0 +1,9 @@
+fos_oauth_server:
+    db_driver: orm       # Drivers available: orm, mongodb, propel or custom
+    client_class:        FOS\OAuthServerBundle\Entity\Client
+    access_token_class:  FOS\OAuthServerBundle\Entity\AccessToken
+    refresh_token_class: FOS\OAuthServerBundle\Entity\RefreshToken
+    auth_code_class:     FOS\OAuthServerBundle\Entity\AuthCode
+framework:
+    templating:
+        engines: ['twig']

--- a/tienvx/fos-oauth-server-bundle-orm/1.0/manifest.json
+++ b/tienvx/fos-oauth-server-bundle-orm/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "FOS\\OAuthServerBundle\\FOSOAuthServerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

FOSOAuthServerBundle does not support Symfony 5.0, so does this recipe.
