### PR TITLE
Add tienvx/fos-oauth-server-bundle-propel

### DIFF
--- a/tienvx/fos-oauth-server-bundle-propel/1.0/config/packages/fos_oauth_server_propel.yaml
+++ b/tienvx/fos-oauth-server-bundle-propel/1.0/config/packages/fos_oauth_server_propel.yaml
@@ -1,0 +1,9 @@
+fos_oauth_server:
+    db_driver: propel    # Drivers available: orm, mongodb, propel or custom
+    client_class:        FOS\OAuthServerBundle\Propel\Client
+    access_token_class:  FOS\OAuthServerBundle\Propel\AccessToken
+    refresh_token_class: FOS\OAuthServerBundle\Propel\RefreshToken
+    auth_code_class:     FOS\OAuthServerBundle\Propel\AuthCode
+framework:
+    templating:
+        engines: ['twig']

--- a/tienvx/fos-oauth-server-bundle-propel/1.0/manifest.json
+++ b/tienvx/fos-oauth-server-bundle-propel/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "FOS\\OAuthServerBundle\\FOSOAuthServerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

FOSOAuthServerBundle does not support Symfony 5.0, so does this recipe.
