### PR TITLE
Configure gpslab/geoip2:~2.0

### DIFF
--- a/gpslab/geoip2/2.0/config/packages/gpslab_geoip.yaml
+++ b/gpslab/geoip2/2.0/config/packages/gpslab_geoip.yaml
@@ -2,7 +2,7 @@
 # https://github.com/gpslab/geoip2
 gpslab_geoip:
     # You should specify your personal licence key
-    license: '%env(GEOIP_LICENSE)%'
+    license: 'YOUR-LICENSE-KEY'
 
     # Edition ID of database you need
     edition: 'GeoLite2-City'

--- a/gpslab/geoip2/2.0/config/packages/gpslab_geoip.yaml
+++ b/gpslab/geoip2/2.0/config/packages/gpslab_geoip.yaml
@@ -1,8 +1,8 @@
 # Read the README file for more detailed configuration information
 # https://github.com/gpslab/geoip2
-#gpslab_geoip:
-#    # You should specify your personal licence key
-#    license: '%env(GEOIP_LICENSE)%'
-#
-#    # Edition ID of database you need
-#    edition: 'GeoLite2-City'
+gpslab_geoip:
+    # You should specify your personal licence key
+    license: '%env(GEOIP_LICENSE)%'
+
+    # Edition ID of database you need
+    edition: 'GeoLite2-City'

--- a/gpslab/geoip2/2.0/config/packages/gpslab_geoip.yaml
+++ b/gpslab/geoip2/2.0/config/packages/gpslab_geoip.yaml
@@ -1,0 +1,8 @@
+# Read the README file for more detailed configuration information
+# https://github.com/gpslab/geoip2
+#gpslab_geoip:
+#    # You should specify your personal licence key
+#    license: '%env(GEOIP_LICENSE)%'
+#
+#    # Edition ID of database you need
+#    edition: 'GeoLite2-City'

--- a/gpslab/geoip2/2.0/manifest.json
+++ b/gpslab/geoip2/2.0/manifest.json
@@ -9,6 +9,6 @@
         "geoip2:update": "symfony-cmd"
     },
     "env": {
-        "GEOIP_LICENSE": ""
+        "GEOIP_LICENSE": "YOUR-LICENSE-KEY"
     }
 }

--- a/gpslab/geoip2/2.0/manifest.json
+++ b/gpslab/geoip2/2.0/manifest.json
@@ -1,0 +1,14 @@
+{
+    "bundles": {
+        "GpsLab\\Bundle\\GeoIP2Bundle\\GpsLabGeoIP2Bundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "composer-scripts": {
+        "geoip2:update": "symfony-cmd"
+    },
+    "env": {
+        "GEOIP_LICENSE": ""
+    }
+}

--- a/gpslab/geoip2/2.0/manifest.json
+++ b/gpslab/geoip2/2.0/manifest.json
@@ -7,8 +7,5 @@
     },
     "composer-scripts": {
         "geoip2:update": "symfony-cmd"
-    },
-    "env": {
-        "GEOIP_LICENSE": "YOUR-LICENSE-KEY"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

The [`gpslab/geoip2`](https://github.com/gpslab/geoip2) package has a [new major release](https://github.com/gpslab/geoip2/releases/tag/v2.0.0) and needs update the recipe configuration for this release.


Before

```yml
gpslab_geoip:
    cache: '%kernel.cache_dir%/GeoLite2-City.mmdb'
    url: 'https://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz'
    locales: [ 'en' ]
```

After

```yml
gpslab_geoip:
    license: 'XXXXXXXXXXXXXXXX'
    edition: 'GeoLite2-City'
    path: '%kernel.cache_dir%/GeoLite2-City.mmdb'
    url: 'https://download.maxmind.com/app/geoip_download?edition_id=%s&license_key=%s&suffix=tar.gz'
    locales: [ 'en' ]
```