### PR TITLE
KunstmaanNodeBundle: Disable permissions by default for v5.5+

### DIFF
--- a/kunstmaan/node-bundle/5.5/config/packages/kunstmaan_node.yaml
+++ b/kunstmaan/node-bundle/5.5/config/packages/kunstmaan_node.yaml
@@ -1,0 +1,4 @@
+kunstmaan_node:
+    lock:
+        enabled: true
+    enable_permissions: false

--- a/kunstmaan/node-bundle/5.5/config/routes/kunstmaan_node.yaml
+++ b/kunstmaan/node-bundle/5.5/config/routes/kunstmaan_node.yaml
@@ -1,0 +1,1 @@
+../../../5.2/config/routes/kunstmaan_node.yaml

--- a/kunstmaan/node-bundle/5.5/manifest.json
+++ b/kunstmaan/node-bundle/5.5/manifest.json
@@ -1,0 +1,1 @@
+../5.2/manifest.json


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This feature is not required by default and will provide a better user experience with symfony 4.4 (trackingUsageTokenStorage changes)
