### PR TITLE
Add tilleuls/sylius-quick-import-plugin

### DIFF
--- a/tilleuls/sylius-quick-import-plugin/0.1/config/routes/sylius_quick_import.yaml
+++ b/tilleuls/sylius-quick-import-plugin/0.1/config/routes/sylius_quick_import.yaml
@@ -1,0 +1,3 @@
+coop_tilleuls_sylius_quick_import_admin:
+    resource: "@CoopTilleulsSyliusQuickImportPlugin/Resources/config/admin_routing.yml"
+    prefix: /admin

--- a/tilleuls/sylius-quick-import-plugin/0.1/manifest.json
+++ b/tilleuls/sylius-quick-import-plugin/0.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "CoopTilleuls\\SyliusQuickImportPlugin\\CoopTilleulsSyliusQuickImportPlugin": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

> This plugin has been written during the COVID-19 pandemic. The goal was to allow shoppers to build quick website and to import catalog without effort.

https://github.com/coopTilleuls/CoopTilleulsSyliusQuickImportPlugin