### PR TITLE
Add tilleuls/sylius-click-n-collect-plugin

### DIFF
--- a/tilleuls/sylius-click-n-collect-plugin/0.1/config/packages/sylius_click_n_collect.yaml
+++ b/tilleuls/sylius-click-n-collect-plugin/0.1/config/packages/sylius_click_n_collect.yaml
@@ -1,0 +1,3 @@
+imports:
+    # ...
+    - { resource: "@CoopTilleulsSyliusClickNCollectPlugin/Resources/config/app/config.yml" }

--- a/tilleuls/sylius-click-n-collect-plugin/0.1/config/routes/sylius_click_n_collect.yaml
+++ b/tilleuls/sylius-click-n-collect-plugin/0.1/config/routes/sylius_click_n_collect.yaml
@@ -1,0 +1,9 @@
+coop_tilleuls_sylius_click_n_collect_shop:
+    resource: "@CoopTilleulsSyliusClickNCollectPlugin/Resources/config/shop_routing.yml"
+    prefix: /{_locale}
+    requirements:
+        _locale: ^[a-z]{2}(?:_[A-Z]{2})?$
+
+coop_tilleuls_sylius_click_n_collect_admin:
+    resource: "@CoopTilleulsSyliusClickNCollectPlugin/Resources/config/admin_routing.yml"
+    prefix: /admin

--- a/tilleuls/sylius-click-n-collect-plugin/0.1/manifest.json
+++ b/tilleuls/sylius-click-n-collect-plugin/0.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "CoopTilleuls\\SyliusClickNCollectPlugin\\CoopTilleulsSyliusClickNCollectPlugin": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/tilleuls/sylius-click-n-collect-plugin/0.1/post-install.txt
+++ b/tilleuls/sylius-click-n-collect-plugin/0.1/post-install.txt
@@ -1,0 +1,11 @@
+<bg=blue;fg=white>                         </>
+<bg=blue;fg=white> Finish the installation </>
+<bg=blue;fg=white>                         </>
+
+  * You're not ready to use the plugin yet. First you must:
+    1. Update your entities
+    2. Override the default templates
+    3. Create your Click 'N' Collect locations
+    4. Create a shipping method
+
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/coopTilleuls/CoopTilleulsSyliusClickNCollectPlugin#install</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

> Sell and deliver securely during the COVID-19 pandemic!
>
> Les-Tilleuls.coop Click and Collect allows to transform your physical shop in an eCommerce shop in minutes, and to allow your customer to pickup their orders while not putting them or your workers at risk!

https://github.com/coopTilleuls/CoopTilleulsSyliusClickNCollectPlugin
