### PR TITLE
add scylabs/neptune-installer package

### DIFF
--- a/scylabs/neptune-installer/1.0/manifest.json
+++ b/scylabs/neptune-installer/1.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "copy-from-package": {
+        "public/css/": "%PUBLIC_DIR%/css/"
+    }
+}


### PR DESCRIPTION
Adding first version to scylabs/neptune-installer recipes before adding scripts files.