### PR TITLE
Kunstmaan/search-bundle: Setup parameter for ES7 support in v5.6

### DIFF
--- a/kunstmaan/search-bundle/5.6/config/packages/kunstmaan_search.yaml
+++ b/kunstmaan/search-bundle/5.6/config/packages/kunstmaan_search.yaml
@@ -1,0 +1,8 @@
+# Default we set the used elasticsearch version to 7 in the "kunstmaan_search.elasticsearch_version" parameter.
+# If you want to use Elasticsearch 6, change the value of the "kunstmaan_search.elasticsearch_version" parameter to "6" and run "composer req ruflin/elastica ^6.0"
+kunstmaan_search:
+    connection:
+        driver: elastic_search
+        host: localhost
+        port: 9200
+    index_prefix: myproject # TODO: Change this prefix to you liking. Maybe the name of your project

--- a/kunstmaan/search-bundle/5.6/manifest.json
+++ b/kunstmaan/search-bundle/5.6/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Kunstmaan\\SearchBundle\\KunstmaanSearchBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "container": {
+        "kunstmaan_search.elasticsearch_version": "7"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

In Kunstmaan/KunstmaanBundlesCMS#2695 we added support for Elasticsearch 7. This recipe change add the correct config to get the user up and running and some info to switch to a lower version.
