### PR TITLE
Fix wrong class name for kerox/twig-image-placeholder-extension

### DIFF
--- a/kerox/twig-image-placeholder-extension/1.0/config/packages/kerox_twig_image_placeholder.yaml
+++ b/kerox/twig-image-placeholder-extension/1.0/config/packages/kerox_twig_image_placeholder.yaml
@@ -1,5 +1,5 @@
 services:
-    Kerox\TwigImagePlaceholder\SvgExtension:
+    Kerox\TwigImagePlaceholder\SvgPlaceholderExtension:
         autowire: true
         autoconfigure: true
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
