### PR TITLE
Update storage directory for PayumBundle

### DIFF
--- a/payum/payum-bundle/2.4/config/payum.yaml
+++ b/payum/payum-bundle/2.4/config/payum.yaml
@@ -2,14 +2,14 @@ payum:
     storages:
         Payum\Core\Model\Payment:
             filesystem:
-                storage_dir: '%kernel.root_dir%/Resources/payments'
+                storage_dir: '%kernel.project_dir%/var/payum/payments'
                 id_property: number
 
     security:
         token_storage:
             Payum\Core\Model\Token:
                 filesystem:
-                    storage_dir: '%kernel.root_dir%/Resources/gateways'
+                    storage_dir: '%kernel.project_dir%/var/payum/gateways'
                     id_property: hash
 
     gateways:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The current recipe for [PayumBundle](https://github.com/Payum/PayumBundle) uses the old directory structure of Symfony < 4. This update changes the location of the storage to use `kernel.project_dir` instead of `kernel.root_dir`, and also uses the `var` folder for storage instead of `app/Resources`.
This ensures compatibility with all the latest versions of Symfony.
