### PR TITLE
Corrected service id in configuration file

### DIFF
--- a/sonata-project/page-bundle/3.9/config/packages/sonata_page.yaml
+++ b/sonata-project/page-bundle/3.9/config/packages/sonata_page.yaml
@@ -10,7 +10,7 @@ sonata_admin:
             - bundles/sonatapage/sonata-page.back.min.css
 
 sonata_page:
-    slugify_service: sonata.core.slugify.cocur
+    slugify_service: sonata.page.slugify.cocur
     multisite: host
     use_streamed_response: false
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Using the correct service id for the slugify service configuration.
The service id is available in the page bundle itself and this also removes a dependency on the now deprecated and abandoned sonata core bundle.