### PR TITLE
Sulu sylius integration

### DIFF
--- a/sulu/sylius-consumer-bundle/0.4/config/packages/sulu_sylius_consumer.yaml
+++ b/sulu/sylius-consumer-bundle/0.4/config/packages/sulu_sylius_consumer.yaml
@@ -1,0 +1,13 @@
+sulu_sylius_consumer:
+    sylius_base_url: '%env(SYLIUS_BASE_URL)%'
+    taxon_category_adapter:
+        enabled: true
+
+framework:
+    messenger:
+        transports:
+            sulu_sylius_transport: '%env(SULU_SYLIUS_MESSENGER_TRANSPORT_DSN)%'
+        buses:
+            sulu_sylius_producer.messenger_bus:
+                middleware:
+                    - doctrine_transaction

--- a/sulu/sylius-consumer-bundle/0.4/config/packages/sulu_sylius_consumer.yaml
+++ b/sulu/sylius-consumer-bundle/0.4/config/packages/sulu_sylius_consumer.yaml
@@ -1,7 +1,7 @@
 sulu_sylius_consumer:
     sylius_base_url: '%env(SYLIUS_BASE_URL)%'
-    taxon_category_adapter:
-        enabled: true
+    # taxon_category_adapter:
+    #     enabled: true
 
 framework:
     messenger:

--- a/sulu/sylius-consumer-bundle/0.4/manifest.json
+++ b/sulu/sylius-consumer-bundle/0.4/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Sulu\\Bundle\\SyliusConsumerBundle\\SuluSyliusConsumerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "SYLIUS_BASE_URL": "",
+        "SULU_SYLIUS_MESSENGER_TRANSPORT_DSN": ""
+    }
+}

--- a/sulu/sylius-producer-plugin/0.2/config/packages/sulu_sylius_producer.yaml
+++ b/sulu/sylius-producer-plugin/0.2/config/packages/sulu_sylius_producer.yaml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: "@SuluSyliusProducerPlugin/Resources/config/app/config.yaml" }
+
+framework:
+    messenger:
+        transports:
+            sulu_sylius_transport: '%env(SULU_SYLIUS_MESSENGER_TRANSPORT_DSN)%'

--- a/sulu/sylius-producer-plugin/0.2/manifest.json
+++ b/sulu/sylius-producer-plugin/0.2/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Sulu\\Bundle\\SyliusProducerPlugin\\SuluSyliusProducerPlugin": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "SULU_SYLIUS_MESSENGER_TRANSPORT_DSN": ""
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Linked to packages:

* https://github.com/sulu/SuluSyliusConsumerBundle
* https://github.com/sulu/SuluSyliusProducerPlugin

The CI is failing because there is no phpcr/phpcr-implementation available. This is required in sulu's skeleton, see https://github.com/sulu/skeleton/blob/2.x/composer.json#L38

Already explained here #995 (comment) by @alexander-schranz