### PR TITLE
Add yaml to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ root = true
 [*]
 end_of_line = LF
 
-[*.json]
+[*.{json,yaml}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The linter is yelling if `.yaml` files are not indent with 4 spaces so to prevent this for future recipes I added the extension to `.editorconfig` 😬 
