### PR TITLE
[PHP_CodeSniffer] Update php_codesniffer recipe to use PSR12.

### DIFF
--- a/squizlabs/php_codesniffer/3.6/manifest.json
+++ b/squizlabs/php_codesniffer/3.6/manifest.json
@@ -1,1 +1,9 @@
-../3.0/manifest.json
+{
+    "copy-from-recipe": {
+        "phpcs.xml.dist": "phpcs.xml.dist"
+    },
+    "gitignore": [
+        "/.phpcs-cache",
+        "/phpcs.xml"
+    ]
+}

--- a/squizlabs/php_codesniffer/3.6/manifest.json
+++ b/squizlabs/php_codesniffer/3.6/manifest.json
@@ -1,0 +1,1 @@
+../3.0/manifest.json

--- a/squizlabs/php_codesniffer/3.6/phpcs.xml.dist
+++ b/squizlabs/php_codesniffer/3.6/phpcs.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <rule ref="PSR12"/>
+
+    <file>bin/</file>
+    <file>config/</file>
+    <file>public/</file>
+    <file>src/</file>
+    <file>tests/</file>
+
+</ruleset>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

Wasn't sure about the version bump but _think_ this is right...

* Added `3.6` (as that's the latest version of `php_codesniffer`) due to 'BC break' of changing the coding standard.
* Symlinked manifest file to `3.0` version (as didn't change)

I realise the vast majority of people using symfony will use php-cs-fixer, but for those who do wish to use `php_codesniffer` the Symfony standard isn't easily supported (there are [community efforts](https://github.com/djoos/Symfony-coding-standard) I believe). However, for simplicity and to be in line with the previous version I think it makes sense to just keep this to PSR12. 