### PR TITLE
kunstmaan/admin-bundle: Disable exception logging by default

### DIFF
--- a/kunstmaan/admin-bundle/5.9/config/packages/kunstmaan_admin.yaml
+++ b/kunstmaan/admin-bundle/5.9/config/packages/kunstmaan_admin.yaml
@@ -1,0 +1,7 @@
+kunstmaan_admin:
+    multi_language: true
+    required_locales: nl|fr|en
+    default_locale: en
+    admin_locales: ['en']
+    website_title: 'MyProject' #Rename this to your website name
+    exception_logging: false

--- a/kunstmaan/admin-bundle/5.9/config/routes/kunstmaan_admin.yaml
+++ b/kunstmaan/admin-bundle/5.9/config/routes/kunstmaan_admin.yaml
@@ -1,0 +1,6 @@
+KunstmaanAdminBundle:
+    resource: "@KunstmaanAdminBundle/Resources/config/routing.yml"
+    # If your site is not multi language, remove the "{_locale}/" part of prefix and requirements
+    prefix:   /{_locale}/
+    requirements:
+        _locale: "%kunstmaan_admin.required_locales%"

--- a/kunstmaan/admin-bundle/5.9/manifest.json
+++ b/kunstmaan/admin-bundle/5.9/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Kunstmaan\\AdminBundle\\KunstmaanAdminBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

The upcoming 5.9 version allows to disable the exception logging module and this is a more sensible default config. The 5.9 version is not yet released, but this PR prepare the recipe already