### PR TITLE
Add recipe for monsieurbiz/sylius-rich-editor-plugin in v2

### DIFF
--- a/monsieurbiz/sylius-rich-editor-plugin/2.0/config/packages/monsieurbiz_sylius_rich_editor_plugin.yaml
+++ b/monsieurbiz/sylius-rich-editor-plugin/2.0/config/packages/monsieurbiz_sylius_rich_editor_plugin.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: "@MonsieurBizSyliusRichEditorPlugin/Resources/config/config.yaml" }

--- a/monsieurbiz/sylius-rich-editor-plugin/2.0/config/routes/monsieurbiz_sylius_rich_editor_plugin.yaml
+++ b/monsieurbiz/sylius-rich-editor-plugin/2.0/config/routes/monsieurbiz_sylius_rich_editor_plugin.yaml
@@ -1,0 +1,3 @@
+monsieurbiz_richeditor_admin:
+    resource: "@MonsieurBizSyliusRichEditorPlugin/Resources/config/routing/admin.yaml"
+    prefix: /%sylius_admin.path_name%

--- a/monsieurbiz/sylius-rich-editor-plugin/2.0/manifest.json
+++ b/monsieurbiz/sylius-rich-editor-plugin/2.0/manifest.json
@@ -1,0 +1,10 @@
+{
+    "bundles": {
+        "MonsieurBiz\\SyliusRichEditorPlugin\\MonsieurBizSyliusRichEditorPlugin": [
+            "all"
+        ]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT


See https://github.com/symfony/recipes-contrib/pull/914 for the v1.

The recipe is almost the same. The routing is a bit different and needs a new version of the recipe.
