### PR TITLE
Remove invalid Flysystem instructions

### DIFF
--- a/league/flysystem-bundle/1.0/post-install.txt
+++ b/league/flysystem-bundle/1.0/post-install.txt
@@ -3,13 +3,6 @@
 <bg=blue;fg=white> What's next?                                </>
 <bg=blue;fg=white>                                             </>
 
-  * <fg=blue>Use</> the default storage immediately:
-
-      public function __construct(FilesystemInterface $defaultStorage)
-      {
-          ...
-      }
-
   * <fg=blue>Configure</> your own storages in <comment>config/packages/flysystem.yaml</comment>.
 
   * <fg=blue>Read</> the documentation at:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This will fix #1101

These instructions are not needed and they will differ from Flysystem v1 vs v2. Fyi @tgalopin 