### PR TITLE
Run Travis on PHP 8 and drop SF 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,10 @@ cache:
 matrix:
     fast_finish: true
     include:
-        - php: 7.4
-          env: SKELETON_VERSION="^3.4"
-        - php: 7.4
+        - php: 8.0
           env: SKELETON_VERSION="^4.4"
-        - php: 7.4
+        - php: 8.0
           env: SKELETON_VERSION="^5.0"
-    allow_failures:
-        - php: 7.4
-          env: SKELETON_VERSION="^3.4"
 
 before_install:
     - phpenv config-rm xdebug.ini || true
@@ -32,7 +27,7 @@ install:
 before_script:
   - |
     install_package() {
-        composer require $@;
+        composer require --ignore-platform-reqs $@;
         EXIT_CODE=$?;
 
         MESSAGE="";

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 before_script:
   - |
     install_package() {
-        composer require --ignore-platform-reqs $@;
+        composer require $@;
         EXIT_CODE=$?;
 
         MESSAGE="";


### PR DESCRIPTION
The problem when the project uses symfony/framework-bundle.
composer require --ignore-platform-reqs install  psr/cache 2.0, his support only PHP 8, but in Travis use PHP 7.4.
1) Remove --ignore-platform-reqs 
or 
2) Use in build PHP 8.0

PHP 8.0 now many libraries does not use this version, because I think good idea remove --ignore-platform-reqs

| Q             | A
| ------------- | ---
| License       | MIT
