### PR TITLE
Add recipes for Jane AutoMapper v7 release

### DIFF
--- a/jane-php/automapper-bundle/7.0/manifest.json
+++ b/jane-php/automapper-bundle/7.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Jane\\Bundle\\AutoMapperBundle\\JaneAutoMapperBundle": ["all"]
+    }
+}

--- a/jane-php/json-schema/6.0/post-install.txt
+++ b/jane-php/json-schema/6.0/post-install.txt
@@ -6,7 +6,8 @@
     1. Configure <comment>config/jane/json_schema.php</> with your specification details
     2. Run <comment>bin/jane-json-schema-generate</>
     3. Add <comment>generated/</> directory to your composer autoload definition (eg. <comment>"MyApp\\Library\\Generated\\": "generated/"</>)
-    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\</> namespace with your generated namespace.
+    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\\</> namespace with your generated namespace.
     5. Then remove line comments
 
 Documentation: https://jane.readthedocs.io/en/latest/
+Repository: https://github.com/janephp/janephp

--- a/jane-php/open-api-common/6.0/post-install.txt
+++ b/jane-php/open-api-common/6.0/post-install.txt
@@ -1,12 +1,13 @@
 <bg=blue;fg=white>                       </>
-<bg=blue;fg=white> JanePHP - JSON Schema </>
+<bg=blue;fg=white> JanePHP - OpenAPI     </>
 <bg=blue;fg=white>                       </>
 
   * <fg=blue>Finish</> package configuration:
     1. Configure <comment>config/jane/open_api.php</> with your specification details
     2. Run <comment>bin/jane-open-api-generate</>
     3. Add <comment>generated/</> directory to your composer autoload definition (eg. <comment>"MyApp\\Library\\Generated\\": "generated/"</>)
-    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\</> namespace with your generated namespace.
+    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\\</> namespace with your generated namespace.
     5. Then remove line comments
 
 Documentation: https://jane.readthedocs.io/en/latest/
+Repository: https://github.com/janephp/janephp


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR adds all needed recipes for Jane v7 release including following components or bundle:
- `jane-php/automapper-bundle`, will require to add the bundle to the bundle list;
