### PR TITLE
Fix compatibility with Webpack-Encore in bref/symfony-bridge

### DIFF
--- a/bref/symfony-bridge/0.1/serverless.yaml
+++ b/bref/symfony-bridge/0.1/serverless.yaml
@@ -43,3 +43,5 @@ package:
         # If you want to include files and folders that are part of excluded folders,
         # add them at the end
         - 'var/cache/prod/**'
+        - 'public/build/entrypoints.json'
+        - 'public/build/manifest.json'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

At the moment the whole `public/build` directory is excluded. 

This means the `entrypoints.json` and `manifest.json` files are also excluded but are required by Symfony to resolve filenames correctly and load Encore entrypoints in Twig.

Without this, people would get a 500 error when deploying on Lambda.
