### PR TITLE
Add recipe for MeiliSearch

### DIFF
--- a/meilisearch/search-bundle/0.4/config/packages/meili_search.yaml
+++ b/meilisearch/search-bundle/0.4/config/packages/meili_search.yaml
@@ -1,0 +1,9 @@
+meili_search:
+    url: '%env(MEILISEARCH_URL)%'
+    api_key: '%env(MEILISEARCH_API_KEY)%'
+    prefix: '%env(MEILISEARCH_PREFIX)%' # Use a prefix for index names based on env var
+#    indices:
+#        - name: samples
+#          class: App\Entity\Sample
+#        - name: other_samples
+#          class: App\Entity\OtherSample

--- a/meilisearch/search-bundle/0.4/manifest.json
+++ b/meilisearch/search-bundle/0.4/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "MeiliSearch\\Bundle\\MeiliSearchBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "MEILISEARCH_URL": "http://127.0.0.1:7700",
+        "MEILISEARCH_API_KEY": "",
+        "MEILISEARCH_PREFIX": "app_"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

This PR adds the recipe for the [meilisearch/meilisearch-symfony](https://github.com/meilisearch/meilisearch-symfony) bundle.
