### PR TITLE
add yaml 4 spaces indent rule in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ root = true
 [*]
 end_of_line = LF
 
-[*.json]
+[*.{json,yaml}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
I propose to add this rule to the .editorconfig file.