### PR TITLE
Fix link to Algolia documentation

### DIFF
--- a/algolia/search-bundle/3.0/post-install.txt
+++ b/algolia/search-bundle/3.0/post-install.txt
@@ -5,4 +5,4 @@
   * Edit the configuration in <fg=green>config/packages/algolia_search.yaml</>
     to start indexing your data.
 
-Documentation: https://www.algolia.com/doc/api-client/symfony/
+Documentation: https://www.algolia.com/doc/framework-integration/symfony/getting-started/algolia-searchbundle/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | <!-- Link to package on packagist -->

This updates the link to the Algolia documentation, which results in a 404 currently.