### PR TITLE
Add recipe for rikudou/psr6-dynamo-db-bundle

### DIFF
--- a/rikudou/psr6-dynamo-db-bundle/2.0/config/packages/prod/rikudou_dynamo_db_cache.yaml
+++ b/rikudou/psr6-dynamo-db-bundle/2.0/config/packages/prod/rikudou_dynamo_db_cache.yaml
@@ -1,0 +1,6 @@
+rikudou_dynamo_db_cache:
+    table: '%env(DYNAMODB_CACHE_TABLE)%'
+    # Use DynamoDB by default for cache & sessions
+    replace_default_adapter: true
+    client_config:
+        region: '%env(AWS_REGION)%'

--- a/rikudou/psr6-dynamo-db-bundle/2.0/manifest.json
+++ b/rikudou/psr6-dynamo-db-bundle/2.0/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Rikudou\\DynamoDbCacheBundle\\RikudouDynamoDbCacheBundle": ["prod"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "DYNAMODB_CACHE_TABLE": "cache",
+        "#AWS_REGION": "us-east-1"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/rikudou/psr6-dynamo-db-bundle

This bundle provides a PSR-6 cache adapter for Symfony + a Session handler both storing data in AWS DynamoDB.

I enabled it only in `prod` because it would otherwise require a local DynamoDB emulator (probably using Docker) or a real DynamoDB table for local development which is not ideal.

Also, `AWS_REGION` is commented because
* it could already be defined if using another AWS-related package 
* it might be predefined in an AWS environment (eg. variables exists in AWS Lambda).

@RikudouSage would love your thoughts on this before going further.
