### PR TITLE
kunstmaan/admin-bundle: Use new authentication system by default

### DIFF
--- a/kunstmaan/admin-bundle/5.10/config/packages/kunstmaan_admin.yaml
+++ b/kunstmaan/admin-bundle/5.10/config/packages/kunstmaan_admin.yaml
@@ -1,0 +1,9 @@
+kunstmaan_admin:
+    multi_language: true
+    required_locales: nl|fr|en
+    default_locale: en
+    admin_locales: ['en']
+    website_title: 'MyProject' #Rename this to your website name
+    exception_logging: false
+    authentication:
+        enable_new_authentication: true

--- a/kunstmaan/admin-bundle/5.10/config/routes/kunstmaan_admin.yaml
+++ b/kunstmaan/admin-bundle/5.10/config/routes/kunstmaan_admin.yaml
@@ -1,0 +1,6 @@
+KunstmaanAdminBundle:
+    resource: "@KunstmaanAdminBundle/Resources/config/routing.yml"
+    # If your site is not multi language, remove the "{_locale}/" part of prefix and requirements
+    prefix:   /{_locale}/
+    requirements:
+        _locale: "%kunstmaan_admin.required_locales%"

--- a/kunstmaan/admin-bundle/5.10/manifest.json
+++ b/kunstmaan/admin-bundle/5.10/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Kunstmaan\\AdminBundle\\KunstmaanAdminBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/kunstmaan/admin-bundle

The old system is deprecated, this recipe makes sure that new installs will use the new authentication system