### PR TITLE
`FollowSymlinks` to be enabled at any times

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -18,6 +18,10 @@ DirectoryIndex index.php
 </IfModule>
 
 <IfModule mod_rewrite.c>
+    # This Option needs to be enabled for RewriteRule, otherwise it will show an error like
+    # 'Options FollowSymLinks or SymLinksIfOwnerMatch is off which implies that RewriteRule directive is forbidden'
+    Options +FollowSymlinks
+
     RewriteEngine On
 
     # Determine the RewriteBase automatically and set it as environment variable.


### PR DESCRIPTION
RewriteRule needs FollowSymlinks to be enabled at any times

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | <!-- Link to package on packagist -->

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

without the Option you get:
> AH00670: Options FollowSymLinks and SymLinksIfOwnerMatch are both off, so the RewriteRule directive is also forbidden due to its similar ability to circumvent directory restrictions