### PR TITLE
Add recipe for drenso/symfony-oidc-bundle v2

### DIFF
--- a/drenso/symfony-oidc-bundle/2.0/config/packages/drenso_oidc.yaml
+++ b/drenso/symfony-oidc-bundle/2.0/config/packages/drenso_oidc.yaml
@@ -1,18 +1,18 @@
 drenso_oidc:
-  #default_client: default # The default client, will be aliased to OidcClientInterface
-  clients:
-    default: # The client name, each client will be aliased to its name (for example, $defaultOidcClient)
-      # Required OIDC client configuration
-      well_known_url: '%env(OIDC_WELL_KNOWN_URL)%'
-      client_id: '%env(OIDC_CLIENT_ID)%'
-      client_secret: '%env(OIDC_CLIENT_SECRET)%'
+    #default_client: default # The default client, will be aliased to OidcClientInterface
+    clients:
+        default: # The client name, each client will be aliased to its name (for example, $defaultOidcClient)
+            # Required OIDC client configuration
+            well_known_url: '%env(OIDC_WELL_KNOWN_URL)%'
+            client_id: '%env(OIDC_CLIENT_ID)%'
+            client_secret: '%env(OIDC_CLIENT_SECRET)%'
 
-      # Extra configuration options
-      #redirect_route: 'login_check'
-      #custom_client_headers: []
+            # Extra configuration options
+            #redirect_route: 'login_check'
+            #custom_client_headers: []
 
-    # Add any extra client
-    #link: # Will be accessible using $linkOidcClient
-      #well_known_url: '%env(LINK_WELL_KNOWN_URL)%'
-      #client_id: '%env(LINK_CLIENT_ID)%'
-      #client_secret: '%env(LINK_CLIENT_SECRET)%'
+        # Add any extra client
+        #link: # Will be accessible using $linkOidcClient
+            #well_known_url: '%env(LINK_WELL_KNOWN_URL)%'
+            #client_id: '%env(LINK_CLIENT_ID)%'
+            #client_secret: '%env(LINK_CLIENT_SECRET)%'

--- a/drenso/symfony-oidc-bundle/2.0/config/packages/drenso_oidc.yaml
+++ b/drenso/symfony-oidc-bundle/2.0/config/packages/drenso_oidc.yaml
@@ -8,7 +8,7 @@ drenso_oidc:
             client_secret: '%env(OIDC_CLIENT_SECRET)%'
 
             # Extra configuration options
-            #redirect_route: 'login_check'
+            #redirect_route: '/login_check'
             #custom_client_headers: []
 
         # Add any extra client

--- a/drenso/symfony-oidc-bundle/2.0/config/packages/drenso_oidc.yaml
+++ b/drenso/symfony-oidc-bundle/2.0/config/packages/drenso_oidc.yaml
@@ -1,0 +1,18 @@
+drenso_oidc:
+  #default_client: default # The default client, will be aliased to OidcClientInterface
+  clients:
+    default: # The client name, each client will be aliased to its name (for example, $defaultOidcClient)
+      # Required OIDC client configuration
+      well_known_url: '%env(OIDC_WELL_KNOWN_URL)%'
+      client_id: '%env(OIDC_CLIENT_ID)%'
+      client_secret: '%env(OIDC_CLIENT_SECRET)%'
+
+      # Extra configuration options
+      #redirect_route: 'login_check'
+      #custom_client_headers: []
+
+    # Add any extra client
+    #link: # Will be accessible using $linkOidcClient
+      #well_known_url: '%env(LINK_WELL_KNOWN_URL)%'
+      #client_id: '%env(LINK_CLIENT_ID)%'
+      #client_secret: '%env(LINK_CLIENT_SECRET)%'

--- a/drenso/symfony-oidc-bundle/2.0/manifest.json
+++ b/drenso/symfony-oidc-bundle/2.0/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "Drenso\\OidcBundle\\DrensoOidcBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "OIDC_WELL_KNOWN_URL": "Enter the .well-known url for the OIDC provider",
+        "OIDC_CLIENT_ID": "Enter your OIDC client id",
+        "OIDC_CLIENT_SECRET": "Enter your OIDC client secret"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/drenso/symfony-oidc-bundle

Adds a recipe for v2 of `drenso/symfony-oidc-bundle`, which should be released soon. The configuration options won't change anymore between the now (the current master branch) and the v2 release.
