### PR TITLE
Add zenstruck/signed-url-bundle

### DIFF
--- a/zenstruck/signed-url-bundle/0.1/manifest.json
+++ b/zenstruck/signed-url-bundle/0.1/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Zenstruck\\ZenstruckSignedUrlBundle": ["all"]
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/zenstruck/signed-url-bundle

Flex's auto-configure bundle doesn't work because of the bundle's namespace.
