### PR TITLE
Delete Hautelook from contrib

### DIFF
--- a/hautelook/alice-bundle/2.1/config/packages/dev/hautelook_alice.yaml
+++ b/hautelook/alice-bundle/2.1/config/packages/dev/hautelook_alice.yaml
@@ -1,2 +1,0 @@
-hautelook_alice:
-    fixtures_path: fixtures

--- a/hautelook/alice-bundle/2.1/config/packages/test/hautelook_alice.yaml
+++ b/hautelook/alice-bundle/2.1/config/packages/test/hautelook_alice.yaml
@@ -1,2 +1,0 @@
-imports:
-    - { resource: ../dev/hautelook_alice.yaml }

--- a/hautelook/alice-bundle/2.1/manifest.json
+++ b/hautelook/alice-bundle/2.1/manifest.json
@@ -1,9 +1,0 @@
-{
-    "bundles": {
-        "Hautelook\\AliceBundle\\HautelookAliceBundle": ["dev", "test"]
-    },
-    "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/",
-        "fixtures/": "fixtures/"
-    }
-}

--- a/hautelook/alice-bundle/2.1/post-install.txt
+++ b/hautelook/alice-bundle/2.1/post-install.txt
@@ -1,2 +1,0 @@
-  * <fg=blue>Write</> fixtures files in the <comment>fixtures/</> folder
-  * <fg=blue>Run</> <comment>php bin/console hautelook:fixtures:load</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | <!-- Link to package on packagist -->

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
This package has been an official recipe for more than 3 years, see https://github.com/symfony/recipes/tree/master/hautelook/alice-bundle/2.1

Thus, it does not belong here as this is misleading and could cause unexpected behaviour. For example, the now retired Flex Server displays a contrib package with aliases which should not happen.

![image](https://user-images.githubusercontent.com/22999032/149637083-b4c01dc7-96e1-4f0c-8497-832d0255e042.png)

It seems the files were only partially removed in https://github.com/symfony/recipes-contrib/pull/523 