### PR TITLE
Update qossmic/deptrac recipe for version 0.19

### DIFF
--- a/qossmic/deptrac-shim/0.19/deptrac.yaml
+++ b/qossmic/deptrac-shim/0.19/deptrac.yaml
@@ -1,0 +1,30 @@
+parameters:
+    paths:
+        - ./src
+    exclude_files:
+        - '#.*test.*#'
+    layers:
+        -
+            name: Controller
+            collectors:
+                -
+                    type: className
+                    regex: .*Controller.*
+        -
+            name: Repository
+            collectors:
+                -
+                    type: className
+                    regex: .*Repository.*
+        -
+            name: Service
+            collectors:
+                -
+                    type: className
+                    regex: .*Service.*
+    ruleset:
+        Controller:
+            - Service
+        Service:
+            - Repository
+        Repository:

--- a/qossmic/deptrac-shim/0.19/manifest.json
+++ b/qossmic/deptrac-shim/0.19/manifest.json
@@ -1,0 +1,8 @@
+{
+    "copy-from-recipe": {
+        "deptrac.yaml": "deptrac.yaml"
+    },
+    "gitignore": [
+        "/.deptrac.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [qossmic/deptrac](https://packagist.org/packages/qossmic/deptrac)

In version 0.19 the default config filename and format has changed
