### PR TITLE
Update broken SncRedisBundle instructions link

### DIFF
--- a/snc/redis-bundle/2.0/config/packages/snc_redis.yaml
+++ b/snc/redis-bundle/2.0/config/packages/snc_redis.yaml
@@ -3,7 +3,7 @@ snc_redis:
 
 # Define your clients here. The example below connects to database 0 of the default Redis server.
 #
-# See https://github.com/snc/SncRedisBundle/blob/master/Resources/doc/index.md for instructions on
+# See https://github.com/snc/SncRedisBundle/blob/master/docs/README.md for instructions on
 # how to configure the bundle.
 #
 #        default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/snc/redis-bundle


The link for further instructions in the SncRedisBundle configuration no longer works.
Corrected it so that it leads to the docs again.