### PR TITLE
Upgrade mongodb-odm-bundle for doctrine/cache 1.11+

### DIFF
--- a/doctrine/mongodb-odm-bundle/4.1/config/packages/doctrine_mongodb.yaml
+++ b/doctrine/mongodb-odm-bundle/4.1/config/packages/doctrine_mongodb.yaml
@@ -1,0 +1,42 @@
+doctrine_mongodb:
+    auto_generate_proxy_classes: true
+    auto_generate_hydrator_classes: true
+    connections:
+        default:
+            server: '%env(resolve:MONGODB_URL)%'
+            options: {}
+    default_database: '%env(resolve:MONGODB_DB)%'
+    document_managers:
+        default:
+            auto_mapping: true
+            mappings:
+                App:
+                    is_bundle: false
+                    type: annotation
+                    dir: '%kernel.project_dir%/src/Document'
+                    prefix: 'App\Document'
+                    alias: App
+
+when@prod:
+    doctrine_mongodb:
+        auto_generate_proxy_classes: false
+        auto_generate_hydrator_classes: false
+        document_managers:
+            default:
+                metadata_cache_driver:
+                    type: service
+                    id: doctrine_mongodb.system_cache_provider
+
+    services:
+        doctrine_mongodb.system_cache_provider:
+            factory: ['Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap']
+            class: 'Doctrine\Common\Cache\Psr6\DoctrineProvider'
+            public: false
+            arguments:
+                - '@doctrine_mongodb.system_cache_pool'
+
+    framework:
+        cache:
+            pools:
+                doctrine_mongodb.system_cache_pool:
+                    adapter: cache.system

--- a/doctrine/mongodb-odm-bundle/4.1/manifest.json
+++ b/doctrine/mongodb-odm-bundle/4.1/manifest.json
@@ -1,0 +1,21 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\MongoDBBundle\\DoctrineMongoDBBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    },
+    "container": {
+        "env(MONGODB_URL)": "",
+        "env(MONGODB_DB)": ""
+    },
+    "env": {
+        "MONGODB_URL": "mongodb://localhost:27017",
+        "MONGODB_DB": "symfony"
+    },
+    "conflict": {
+        "doctrine/cache": "<1.11",
+        "symfony/framework-bundle": "<5.3"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | -

Fix #1351