### PR TITLE
fixing docu url

### DIFF
--- a/stof/doctrine-extensions-bundle/1.2/config/packages/stof_doctrine_extensions.yaml
+++ b/stof/doctrine-extensions-bundle/1.2/config/packages/stof_doctrine_extensions.yaml
@@ -1,4 +1,4 @@
 # Read the documentation: https://symfony.com/doc/current/bundles/StofDoctrineExtensionsBundle/index.html
-# See the official DoctrineExtensions documentation for more details: https://github.com/Atlantic18/DoctrineExtensions/tree/master/doc/
+# See the official DoctrineExtensions documentation for more details: https://github.com/doctrine-extensions/DoctrineExtensions/tree/main/doc
 stof_doctrine_extensions:
     default_locale: en_US


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | <!-- Link to package on packagist -->

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
The package changed its `main` branch and moved to a new GitHub organization.
This fixes the URL to the new package.