### PR TITLE
Remove create_project_php parameter

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -14,5 +14,3 @@ jobs:
             branch: master
             contrib: true
             find_yaml: -not -wholename 'codeception/codeception/*/tests/*' -not -wholename 'codeception/codeception/*/codeception.yml'
-            create_project_php: '8.0'
-


### PR DESCRIPTION
It was removed from the callable workflow https://github.com/symfony/recipes/commit/07cc58ffd13fe05406b7dd23b9e5034c6dfd82fa
It currently breaks the workflow: https://github.com/symfony/recipes-contrib/actions/runs/1962132102/workflow