### PR TITLE
Update google/apiclient recipe

### DIFF
--- a/google/apiclient/2.10/config/packages/google_apiclient.yaml
+++ b/google/apiclient/2.10/config/packages/google_apiclient.yaml
@@ -1,0 +1,11 @@
+services:
+    Google\Client:
+        class: Google\Client
+        calls:
+            # Authentication with "API key"
+            - [setDeveloperKey, ['%env(GOOGLE_API_KEY)%']]
+            # Authentication with "OAuth 2.0" using Client ID & Secret
+            - [setClientId, ['%env(GOOGLE_CLIENT_ID)%']]
+            - [setClientSecret, ['%env(GOOGLE_CLIENT_SECRET)%']]
+            # Authentication with "OAuth 2.0" or "Service account" using JSON
+            - [setAuthConfig, ['%env(resolve:GOOGLE_AUTH_CONFIG)%']]

--- a/google/apiclient/2.10/manifest.json
+++ b/google/apiclient/2.10/manifest.json
@@ -1,0 +1,11 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "GOOGLE_API_KEY": "",
+        "GOOGLE_CLIENT_ID": "",
+        "GOOGLE_CLIENT_SECRET": "",
+        "GOOGLE_AUTH_CONFIG": "%kernel.project_dir%/path/to/file.json"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/google/apiclient

Since 2.10, Google API Client use namespaces: `Google\Client`
`Google_Client` will be deprecated in the future.

See https://github.com/googleapis/google-api-php-client/blob/main/UPGRADING.md#2x-to-2100
