### PR TITLE
Adding `logOutputFile: '/dev/null'`

### DIFF
--- a/nucleos/dompdf-bundle/3.1/config/packages/nucleos_dompdf.yaml
+++ b/nucleos/dompdf-bundle/3.1/config/packages/nucleos_dompdf.yaml
@@ -1,4 +1,4 @@
 nucleos_dompdf:
     defaults:
         chroot: '%kernel.project_dir%/public/assets' # See https://github.com/dompdf/dompdf/wiki/Usage#security-restrictions-for-local-files
-        logOutputFile: '/dev/null' # Prevent creating `/tmp/log.htm` which causes problems in some server configurations
+        logOutputFile: '' # Prevent creating `/tmp/log.htm` which causes problems in some server configurations

--- a/nucleos/dompdf-bundle/3.1/config/packages/nucleos_dompdf.yaml
+++ b/nucleos/dompdf-bundle/3.1/config/packages/nucleos_dompdf.yaml
@@ -1,3 +1,4 @@
 nucleos_dompdf:
     defaults:
         chroot: '%kernel.project_dir%/public/assets' # See https://github.com/dompdf/dompdf/wiki/Usage#security-restrictions-for-local-files
+        logOutputFile: '/dev/null' # Prevent creating `/tmp/log.htm` which causes problems in some server configurations


### PR DESCRIPTION
See https://github.com/dompdf/dompdf/issues/2810#issuecomment-1070927239 for the reason and https://github.com/dompdf/dompdf/issues/1709#issuecomment-466717959 for the solution

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://repo.packagist.org/packages/nucleos/dompdf-bundle
