### PR TITLE
Since Contao 4.10, the path for the routes configuration changed

### DIFF
--- a/contao/installation-bundle/4.10/config/routes/contao_installation.yaml
+++ b/contao/installation-bundle/4.10/config/routes/contao_installation.yaml
@@ -1,0 +1,2 @@
+contao_installation:
+    resource: "@ContaoInstallationBundle/Resources/config/routes.yml"

--- a/contao/installation-bundle/4.10/manifest.json
+++ b/contao/installation-bundle/4.10/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Contao\\InstallationBundle\\ContaoInstallationBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/contao/installation-bundle

Changed the included `routes.yml` which changed from `routing.yml` to `routes.yml` in Contao 4.10.

See: https://github.com/contao/installation-bundle/commit/6a6567fd4985c9fc4ddd02bb40a6060359bfc9a2