### PR TITLE
Add Sonata bridges recipes

### DIFF
--- a/sonata-project/doctrine-extensions/1.8/manifest.json
+++ b/sonata-project/doctrine-extensions/1.8/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Sonata\\Doctrine\\Bridge\\Symfony\\SonataDoctrineBundle": ["all"]
+    }
+}

--- a/sonata-project/exporter/2.4/manifest.json
+++ b/sonata-project/exporter/2.4/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Sonata\\Exporter\\Bridge\\Symfony\\SonataExporterBundle": ["all"]
+    }
+}

--- a/sonata-project/twig-extensions/1.2/manifest.json
+++ b/sonata-project/twig-extensions/1.2/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Sonata\\Twig\\Bridge\\Symfony\\SonataTwigBundle": ["all"]
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sonata-project/doctrine-extensions https://packagist.org/packages/sonata-project/exporter https://packagist.org/packages/sonata-project/twig-extensions

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

This PRs attempts to fix this problem: https://github.com/sonata-project/SonataAdminBundle/issues/7784
We tried to add a hack around flex to be able to auto discover the bundle file for our bridges: 
https://github.com/sonata-project/twig-extensions/pull/100
https://github.com/sonata-project/exporter/pull/345
https://github.com/sonata-project/sonata-doctrine-extensions/pull/209

It was not a really good idea since not only is confusing to have a file like this: 
https://github.com/sonata-project/twig-extensions/blob/1.x/src/Bridge/Symfony/SonataTwigSymfonyBundle.php

But also is not compatible with `classmap-authoritative` as reported in the initial issue