### PR TITLE
Add sulu form bundle 2.4 recipe

### DIFF
--- a/sulu/form-bundle/2.4/config/packages/sulu_form.yaml
+++ b/sulu/form-bundle/2.4/config/packages/sulu_form.yaml
@@ -1,0 +1,8 @@
+sulu_form:
+#   csrf_protection: true # requires additional changes see: https://github.com/sulu/SuluFormBundle/blob/2.4.0/Resources/doc/csrf.md
+    mail:
+        from: "%env(SULU_ADMIN_EMAIL)%"
+        to: "%env(SULU_ADMIN_EMAIL)%"
+        sender: "%env(SULU_ADMIN_EMAIL)%"
+    media:
+        protected: true

--- a/sulu/form-bundle/2.4/config/routes/sulu_form_admin.yaml
+++ b/sulu/form-bundle/2.4/config/routes/sulu_form_admin.yaml
@@ -1,0 +1,4 @@
+sulu_form_api:
+    resource: "@SuluFormBundle/Resources/config/routing_api.yml"
+    type: rest
+    prefix: /admin/api

--- a/sulu/form-bundle/2.4/manifest.json
+++ b/sulu/form-bundle/2.4/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Sulu\\Bundle\\FormBundle\\SuluFormBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/sulu/form-bundle/2.4/post-install.txt
+++ b/sulu/form-bundle/2.4/post-install.txt
@@ -1,0 +1,7 @@
+  * The <fg=green>SuluFormBundle</> is almost ready:
+    1. Print the sql statements required to update your database schema by running <info>php bin/console doctrine:schema:update --dump-sql</>.
+    2. If the statements look fine to you, run the same command using <info>--force</> to execute them.
+    3. Make sure your user has all the necessary permissions for the <fg=green>SuluFormBundle</>.
+    4. Use <info>bin/console sulu:form:generate-form</info> to create a dummy form.
+
+  * <fg=blue>Read</> the documentation at <comment>https://github.com/sulu/SuluFormBundle/blob/2.x/Resources/doc/index.md</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [sulu/form-bundle](github.com/sulu/suluformbundle)

The 2.4 not longer requires enabling of the esi and fragments configuration. So the following was removed: https://github.com/symfony/recipes-contrib/blob/7645718b41e85fdadea21149322cbabf9c2d4840/sulu/form-bundle/2.2/config/packages/sulu_form.yaml#L9-L11