### PR TITLE
Use when@env for jms serializer configuration

### DIFF
--- a/jms/serializer-bundle/4.0/config/packages/jms_serializer.yaml
+++ b/jms/serializer-bundle/4.0/config/packages/jms_serializer.yaml
@@ -1,0 +1,30 @@
+jms_serializer:
+    visitors:
+        xml_serialization:
+            format_output: '%kernel.debug%'
+#    metadata:
+#        auto_detection: false
+#        directories:
+#            any-name:
+#                namespace_prefix: "My\\FooBundle"
+#                path: "@MyFooBundle/Resources/config/serializer"
+#            another-name:
+#                namespace_prefix: "My\\BarBundle"
+#                path: "@MyBarBundle/Resources/config/serializer"
+
+when@prod:
+    jms_serializer:
+        visitors:
+            json_serialization:
+                options:
+                    - JSON_UNESCAPED_SLASHES
+                    - JSON_PRESERVE_ZERO_FRACTION
+
+when@dev:
+    jms_serializer:
+        visitors:
+            json_serialization:
+                options:
+                    - JSON_PRETTY_PRINT
+                    - JSON_UNESCAPED_SLASHES
+                    - JSON_PRESERVE_ZERO_FRACTION

--- a/jms/serializer-bundle/4.0/manifest.json
+++ b/jms/serializer-bundle/4.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "JMS\\SerializerBundle\\JMSSerializerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | jms/serializer-bundle

/cc @goetas 

Symfony switch to use `when@env` everywhere in there core bundle configuraitons.

This will update jms serializer to use als `when@prod` and `when@dev` instead of splitting it into seperate files.