### PR TITLE
Allow `workflow_dispatch` for update workflow

### DIFF
--- a/.github/workflows/flex-update.yml
+++ b/.github/workflows/flex-update.yml
@@ -1,7 +1,7 @@
 name: Update Flex endpoint
 
 on:
-    workflow_dispatch:
+    workflow_dispatch: null
     push:
         branches:
             - main

--- a/.github/workflows/flex-update.yml
+++ b/.github/workflows/flex-update.yml
@@ -1,6 +1,7 @@
 name: Update Flex endpoint
 
 on:
+    workflow_dispatch:
     push:
         branches:
             - main


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Until we know, why the workflow is not dispatched automatically, we should be able to update the flex endpoint manually.