### PR TITLE
Add mongodb-odm-bundle recipe for version 4.4

### DIFF
--- a/doctrine/mongodb-odm-bundle/4.4/config/packages/doctrine_mongodb.yaml
+++ b/doctrine/mongodb-odm-bundle/4.4/config/packages/doctrine_mongodb.yaml
@@ -1,0 +1,34 @@
+doctrine_mongodb:
+    auto_generate_proxy_classes: true
+    auto_generate_hydrator_classes: true
+    connections:
+        default:
+            server: '%env(resolve:MONGODB_URL)%'
+            options: {}
+    default_database: '%env(resolve:MONGODB_DB)%'
+    document_managers:
+        default:
+            auto_mapping: true
+            mappings:
+                App:
+                    is_bundle: false
+                    type: annotation
+                    dir: '%kernel.project_dir%/src/Document'
+                    prefix: 'App\Document'
+                    alias: App
+
+when@prod:
+    doctrine_mongodb:
+        auto_generate_proxy_classes: false
+        auto_generate_hydrator_classes: false
+        document_managers:
+            default:
+                metadata_cache_driver:
+                    type: service
+                    id: doctrine_mongodb.system_cache_pool
+
+    framework:
+        cache:
+            pools:
+                doctrine_mongodb.system_cache_pool:
+                    adapter: cache.system

--- a/doctrine/mongodb-odm-bundle/4.4/manifest.json
+++ b/doctrine/mongodb-odm-bundle/4.4/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\MongoDBBundle\\DoctrineMongoDBBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    },
+    "container": {
+        "env(MONGODB_URL)": "",
+        "env(MONGODB_DB)": ""
+    },
+    "env": {
+        "MONGODB_URL": "mongodb://localhost:27017",
+        "MONGODB_DB": "symfony"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [doctrine/mongodb-odm-bundle](https://packagist.org/packages/doctrine/mongodb-odm-bundle)

The recipe fixes the following deprecation:

Since doctrine/mongodb-odm-bundle 4.4: Configuring doctrine/cache is deprecated. Please update the cache service "doctrine_mongodb.system_cache_provider" to use a PSR-6 cache.