### PR TITLE
leapt/froala-editor-bundle: import PHP routing instead of YAML

### DIFF
--- a/leapt/froala-editor-bundle/1.2/config/packages/leapt_froala_editor.yaml
+++ b/leapt/froala-editor-bundle/1.2/config/packages/leapt_froala_editor.yaml
@@ -1,0 +1,6 @@
+twig:
+    form_themes:
+        - '@LeaptFroalaEditor/Form/froala_widget.html.twig'
+
+leapt_froala_editor:
+    language: en

--- a/leapt/froala-editor-bundle/1.2/config/routes/leapt_froala_editor.yaml
+++ b/leapt/froala-editor-bundle/1.2/config/routes/leapt_froala_editor.yaml
@@ -1,0 +1,3 @@
+leapt_froala_editor:
+    resource: '@LeaptFroalaEditorBundle/Resources/config/routing.php'
+    prefix:   /froala-editor

--- a/leapt/froala-editor-bundle/1.2/manifest.json
+++ b/leapt/froala-editor-bundle/1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Leapt\\FroalaEditorBundle\\LeaptFroalaEditorBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/leapt/froala-editor-bundle
