### PR TITLE
leapt/im-bundle: import PHP routing instead of YAML

### DIFF
--- a/leapt/im-bundle/4.1/config/packages/leapt_im.yaml
+++ b/leapt/im-bundle/4.1/config/packages/leapt_im.yaml
@@ -1,0 +1,7 @@
+# Read the documentation: https://github.com/leapt/im-bundle/blob/master/docs/configuration.rst
+leapt_im:
+    cache_path: cache/im
+    formats:
+        # Resize to fit in 100x100, only if bigger, and remove all crap (meta-data, ...)
+        medium:
+            thumbnail: 100x100>

--- a/leapt/im-bundle/4.1/config/routes/leapt_im.yaml
+++ b/leapt/im-bundle/4.1/config/routes/leapt_im.yaml
@@ -1,0 +1,2 @@
+leapt_im:
+    resource: '@LeaptImBundle/Resources/config/routing.php'

--- a/leapt/im-bundle/4.1/manifest.json
+++ b/leapt/im-bundle/4.1/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Leapt\\ImBundle\\LeaptImBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "gitignore": [
+        "/public/cache/"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/leapt/im-bundle
