### PR TITLE
Fix Jane-php json schema recipe binary for v7 releases

### DIFF
--- a/jane-php/json-schema/7.0/bin/jane-json-schema-generate
+++ b/jane-php/json-schema/7.0/bin/jane-json-schema-generate
@@ -4,8 +4,8 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use Jane\Component\JsonSchema\Console\Command\GenerateCommand;
-use Jane\Component\OpenApiCommon\Console\Loader\ConfigLoader;
-use Jane\Component\OpenApiCommon\Console\Loader\SchemaLoader;
+use Jane\Component\JsonSchema\Console\Loader\ConfigLoader;
+use Jane\Component\JsonSchema\Console\Loader\SchemaLoader;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/jane-php/json-schema

- [X] fix jane php json schema binary, it could work standalone without [open-api-common](https://packagist.org/packages/jane-php/open-api-common)