### PR TITLE
update VichUploaderBundle recipe

### DIFF
--- a/vich/uploader-bundle/1.13/config/packages/vich_uploader.yaml
+++ b/vich/uploader-bundle/1.13/config/packages/vich_uploader.yaml
@@ -1,0 +1,8 @@
+vich_uploader:
+    db_driver: orm
+
+    #mappings:
+    #    products:
+    #        uri_prefix: /images/products
+    #        upload_destination: '%kernel.project_dir%/public/images/products'
+    #        namer: Vich\UploaderBundle\Naming\SmartUniqueNamer

--- a/vich/uploader-bundle/1.13/config/packages/vich_uploader.yaml
+++ b/vich/uploader-bundle/1.13/config/packages/vich_uploader.yaml
@@ -5,4 +5,4 @@ vich_uploader:
     #    products:
     #        uri_prefix: /images/products
     #        upload_destination: '%kernel.project_dir%/public/images/products'
-    #        namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
+    #        namer: Vich\UploaderBundle\Naming\UniquidNamer

--- a/vich/uploader-bundle/1.13/config/packages/vich_uploader.yaml
+++ b/vich/uploader-bundle/1.13/config/packages/vich_uploader.yaml
@@ -5,4 +5,4 @@ vich_uploader:
     #    products:
     #        uri_prefix: /images/products
     #        upload_destination: '%kernel.project_dir%/public/images/products'
-    #        namer: Vich\UploaderBundle\Naming\UniquidNamer
+    #        namer: Vich\UploaderBundle\Naming\SmartUniqueNamer

--- a/vich/uploader-bundle/1.13/manifest.json
+++ b/vich/uploader-bundle/1.13/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Vich\\UploaderBundle\\VichUploaderBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [uploader-bundle](https://packagist.org/packages/vich/uploader-bundle)

Since version 1.13, UploaderBundle deprecated not using a namer. This new configuration reflects the new behaviour.
See also [UPGRADE.md](https://github.com/dustin10/VichUploaderBundle/blob/master/UPGRADE.md#upgrading-from-v1120-to-1130) on bundle repo.
