### PR TITLE
Fix indention of example yaml file

### DIFF
--- a/pasaiakoudala/authbundle/0.1/config/packages/security.yaml.dist
+++ b/pasaiakoudala/authbundle/0.1/config/packages/security.yaml.dist
@@ -1,27 +1,27 @@
 security:
-  enable_authenticator_manager: true
-  password_hashers:
-    PasaiakoUdala\AuthBundle\Entity\User:
-      algorithm: auto
+    enable_authenticator_manager: true
+    password_hashers:
+        PasaiakoUdala\AuthBundle\Entity\User:
+            algorithm: auto
 
-  providers:
-    database_users:
-      entity: { class: PasaiakoUdala\AuthBundle\Entity\User, property: username }
+    providers:
+        database_users:
+            entity: { class: PasaiakoUdala\AuthBundle\Entity\User, property: username }
 
-  firewalls:
-    dev:
-      pattern: ^/(_(profiler|wdt)|css|images|js)/
-      security: false
-    main:
-      #            pattern: ^/
-      lazy: true
-      provider: database_users
-      custom_authenticator: paud.form.auth
-      logout:
-        path: pasaiakoudala_auth_logout
-  #                target: default
+    firewalls:
+        dev:
+            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            security: false
+        main:
+            #            pattern: ^/
+            lazy: true
+            provider: database_users
+            custom_authenticator: paud.form.auth
+            logout:
+                path: pasaiakoudala_auth_logout
+    #                target: default
 
 
-  access_control:
-    #        - { path: ^/login, roles: PUBLIC_ACCESS }
-    - { path: ^/admin, roles: ROLE_ADMIN }
+    access_control:
+        #        - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/admin, roles: ROLE_ADMIN }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | <!-- Link to package on packagist -->

The `security.yaml.dist` is not following the 4 spaces indention which it should.
