### PR TITLE
Fix not defined bundle class in Aziz403/ux-zoom bundle

### DIFF
--- a/aziz403/ux-zoom/1.0/manifest.json
+++ b/aziz403/ux-zoom/1.0/manifest.json
@@ -1,6 +1,6 @@
 {
     "bundles": {
-        "Aziz403\\UX\\Zoom\\ZoomBundle": ["all"]
+        "Aziz403\\UX\\Zoom\\UxZoomBundle": ["all"]
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"

--- a/aziz403/ux-zoom/1.0/manifest.json
+++ b/aziz403/ux-zoom/1.0/manifest.json
@@ -1,4 +1,7 @@
 {
+    "bundles": {
+        "Aziz403\\UX\\Zoom\\ZoomBundle": ["all"]
+    },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | `Aziz403/ux-zoom`

Fix issue of failing CI in the recipe update: https://github.com/schranz-php-recipes/symfony-recipes-php-contrib/actions/runs/3725022578/jobs/6317565427

FYI @Aziz403, requires https://github.com/Aziz403/ux-zoom/pull/1

Related PR: #1466