### PR TITLE
prooph event store recipes

### DIFF
--- a/prooph/event-store-symfony-bundle/0.10/config/packages/prooph_event_store.yaml
+++ b/prooph/event-store-symfony-bundle/0.10/config/packages/prooph_event_store.yaml
@@ -1,0 +1,11 @@
+prooph_event_store:
+    stores:
+        default:
+            event_store: 'app.event_store.default'
+
+services:
+    _defaults:
+        public: false
+
+    Prooph\EventStore\EventStore: '@prooph_event_store.default'
+    Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator: null

--- a/prooph/event-store-symfony-bundle/0.10/manifest.json
+++ b/prooph/event-store-symfony-bundle/0.10/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Prooph\\Bundle\\EventStore\\ProophEventStoreBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    }
+}

--- a/prooph/pdo-event-store/1.15/config/packages/prooph_pdo_event_store.yaml
+++ b/prooph/pdo-event-store/1.15/config/packages/prooph_pdo_event_store.yaml
@@ -1,0 +1,20 @@
+services:
+    _defaults:
+        public: false
+
+    app.event_store.default:
+        class: Prooph\EventStore\Pdo\PostgresEventStore
+        arguments:
+            - '@prooph_event_store.message_factory'
+            - '@app.event_store.pdo_connection.postgres'
+            - '@app.event_store.postgres.persistence_strategy'
+
+    app.event_store.pdo_connection.postgres:
+        class: \PDO
+        arguments:
+            - '%env(EVENT_STORE_DSN)%'
+            - '%env(EVENT_STORE_USER)%'
+            - '%env(EVENT_STORE_PASSWORD)%'
+
+    app.event_store.postgres.persistence_strategy:
+        class: Prooph\EventStore\Pdo\PersistenceStrategy\PostgresSingleStreamStrategy

--- a/prooph/pdo-event-store/1.15/manifest.json
+++ b/prooph/pdo-event-store/1.15/manifest.json
@@ -1,0 +1,13 @@
+{
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "copy-from-package": {
+        "scripts/": "%CONFIG_DIR%/scripts/"
+    },
+    "env": {
+        "EVENT_STORE_DSN": "pgsql:host=127.0.0.1;dbname=event_streams",
+        "EVENT_STORE_USER": "user",
+        "EVENT_STORE_PASSWORD": "password"
+    }
+}

--- a/prooph/pdo-event-store/1.15/post-install.txt
+++ b/prooph/pdo-event-store/1.15/post-install.txt
@@ -1,0 +1,4 @@
+  * Modify your EVENT_STORE_* configuration in <fg=green>.env</>
+
+  * Create event streams and projections tables using SQL scripts
+    in <comment>%CONFIG_DIR%/scripts/*</comment>


### PR DESCRIPTION
event store interface should alias instance which wraps the internal event store client 
wrapper gets registered by bundle package due it is the proper place to define an alias

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/prooph/event-store-symfony-bundle https://packagist.org/packages/prooph/pdo-event-store
