### PR TITLE
Add `register_error_handler` and `hub_id` options for sentry/sentry-symfony

### DIFF
--- a/sentry/sentry-symfony/3.0/config/packages/prod/sentry.yaml
+++ b/sentry/sentry-symfony/3.0/config/packages/prod/sentry.yaml
@@ -5,18 +5,27 @@ sentry:
             - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
             - Symfony\Component\Security\Core\Exception\AccessDeniedException
 
-#    If you are using Monolog, you also need these additional configuration and services to log the errors correctly:
+#    If you are using Monolog, you also need this additional configuration to log the errors correctly:
 #    https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
 #    register_error_listener: false
 
-#    monolog:
-#        handlers:
-#            sentry:
-#                type: service
-#                id: Sentry\Monolog\Handler
+# monolog:
+#     handlers:
+#         sentry:
+#             type: sentry
+#             level: !php/const Monolog\Logger::ERROR
+#             hub_id: Sentry\State\HubInterface
 
-#    services:
-#        Sentry\Monolog\Handler:
-#            arguments:
-#                $hub: '@Sentry\State\HubInterface'
-#                $level: !php/const Monolog\Logger::ERROR
+# If you are using MonologBundle prior to v3.7, you need to configure the handler as a service instead:
+
+# monolog:
+#     handlers:
+#         sentry:
+#             type: service
+#             id: Sentry\Monolog\Handler
+
+# services:
+#     Sentry\Monolog\Handler:
+#         arguments:
+#             $hub: '@Sentry\State\HubInterface'
+#             $level: !php/const Monolog\Logger::ERROR

--- a/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
@@ -5,6 +5,7 @@ when@prod:
 #        If you are using Monolog, you also need this additional configuration to log the errors correctly:
 #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
 #        register_error_listener: false
+#        register_error_handler: false
 
 #    monolog:
 #        handlers:
@@ -12,18 +13,3 @@ when@prod:
 #                type: sentry
 #                level: !php/const Monolog\Logger::ERROR
 #                hub_id: Sentry\State\HubInterface
-
-#    If you are using MonologBundle prior to v3.7, you need to configure the handler as a service instead:
-
-#    monolog:
-#        handlers:
-#            sentry:
-#                type: service
-#                id: Sentry\Monolog\Handler
-
-#    services:
-#        Sentry\Monolog\Handler:
-#            arguments:
-#                $hub: '@Sentry\State\HubInterface'
-#                $level: !php/const Monolog\Logger::ERROR
-#                $bubble: false

--- a/sentry/sentry-symfony/4.6/manifest.json
+++ b/sentry/sentry-symfony/4.6/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "Sentry\\SentryBundle\\SentryBundle": ["prod"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "SENTRY_DSN": ""
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<5.4",
+        "symfony/monolog-bundle": "<3.7"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sentry/sentry-symfony

Adds the `register_error_handler` options added in https://github.com/getsentry/sentry-symfony/pull/687 and the `hub_id` option added in https://github.com/symfony/monolog-bundle/pull/393 .

cc @cleptric