### PR TITLE
Copy monsieurbiz/sylius-no-commerce-plugin@v0.1.* to v1.0

### DIFF
--- a/monsieurbiz/sylius-no-commerce-plugin/1.0/config/packages/monsieurbiz_sylius_nocommerce_plugin.yaml
+++ b/monsieurbiz/sylius-no-commerce-plugin/1.0/config/packages/monsieurbiz_sylius_nocommerce_plugin.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: "@MonsieurBizSyliusNoCommercePlugin/Resources/config/config.yaml" }

--- a/monsieurbiz/sylius-no-commerce-plugin/1.0/manifest.json
+++ b/monsieurbiz/sylius-no-commerce-plugin/1.0/manifest.json
@@ -1,0 +1,10 @@
+{
+    "bundles": {
+        "MonsieurBiz\\SyliusNoCommercePlugin\\MonsieurBizSyliusNoCommercePlugin": [
+            "all"
+        ]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/monsieurbiz/sylius-no-commerce-plugin

We hare released the [1.0 version of the plugin](https://github.com/monsieurbiz/SyliusNoCommercePlugin/releases/tag/v1.0.0).

The recipe has no difference between 0.1 and 1.0 versions. It's just that we realized we could release the official stable version.

Thank you!
