### PR TITLE
Update sylius_mail_tester.yaml

### DIFF
--- a/synolia/sylius-mail-tester-plugin/1.0/config/routes/sylius_mail_tester.yaml
+++ b/synolia/sylius-mail-tester-plugin/1.0/config/routes/sylius_mail_tester.yaml
@@ -1,3 +1,3 @@
 synolia_mail_tester:
     resource: "@SynoliaSyliusMailTesterPlugin/Resources/config/admin_routing.yaml"
-    prefix: /admin
+    prefix: '/%sylius_admin.path_name%'


### PR DESCRIPTION
use `/%sylius_admin.path_name%` instead of `/admin`

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/synolia/sylius-mail-tester-plugin

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
