### PR TITLE
[monsieurbiz/sylius-homepage-plugin] Add missing semicolon in routes

### DIFF
--- a/monsieurbiz/sylius-homepage-plugin/1.0/config/routes/monsieurbiz_sylius_homepage_plugin.yaml
+++ b/monsieurbiz/sylius-homepage-plugin/1.0/config/routes/monsieurbiz_sylius_homepage_plugin.yaml
@@ -8,7 +8,7 @@ monsieurbiz_sylius_homepage_homepage:
     requirements:
         _locale: ^[a-z]{2}(?:_[A-Z]{2})?$
     defaults:
-        _controller: monsieurbiz_homepage.controller.homepage:indexAction
+        _controller: monsieurbiz_homepage.controller.homepage::indexAction
         _sylius:
             template: '@MonsieurBizSyliusHomepagePlugin/Homepage/index.html.twig'
             repository:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [monsieurbiz/sylius-homepage-plugin](https://packagist.org/packages/monsieurbiz/sylius-homepage-plugin)

I've added a semicolon missing in the route of this plugin.