### PR TITLE
Add recipe for Sylius Media Manager plugin

### DIFF
--- a/monsieurbiz/sylius-media-manager-plugin/1.0/config/packages/monsieurbiz_media_manager_plugin.yaml
+++ b/monsieurbiz/sylius-media-manager-plugin/1.0/config/packages/monsieurbiz_media_manager_plugin.yaml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: "@MonsieurBizSyliusMediaManagerPlugin/Resources/config/config.yaml" }
+
+liip_imagine:
+    loaders:
+        default:
+            filesystem:
+                data_root:
+                    - "%sylius_core.public_dir%/media/image"
+                    - "%sylius_core.public_dir%/media" # Add media folder
+twig:
+    form_themes: ['@MonsieurBizSyliusMediaManagerPlugin/Admin/MediaManager/Form/_theme.html.twig']

--- a/monsieurbiz/sylius-media-manager-plugin/1.0/config/routes/monsieurbiz_media_manager_plugin.yaml
+++ b/monsieurbiz/sylius-media-manager-plugin/1.0/config/routes/monsieurbiz_media_manager_plugin.yaml
@@ -1,0 +1,2 @@
+monsieurbiz_sylius_media_manager_admin:
+    resource: "@MonsieurBizSyliusMediaManagerPlugin/Resources/config/routes.yaml"

--- a/monsieurbiz/sylius-media-manager-plugin/1.0/manifest.json
+++ b/monsieurbiz/sylius-media-manager-plugin/1.0/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "MonsieurBiz\\SyliusMediaManagerPlugin\\MonsieurBizSyliusMediaManagerPlugin": [
+            "all"
+        ]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "MONSIEURBIZ_SYLIUS_MEDIA_MANAGER_PUBLIC_FOLDER": "%kernel.project_dir%/public",
+        "MONSIEURBIZ_SYLIUS_MEDIA_MANAGER_ROOT_FOLDER_FROM_PUBLIC": "media",
+        "MONSIEURBIZ_SYLIUS_MEDIA_MANAGER_MAX_FILE_SIZE": "5M"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [monsieurbiz/sylius-media-manager-plugin](https://packagist.org/packages/monsieurbiz/sylius-media-manager-plugin)

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

It's a Sylius plugin it will not works with Symfony only.
See our [Recipe workflow](https://github.com/monsieurbiz/SyliusMediaManagerPlugin/blob/master/.github/workflows/recipe.yaml) which test it in our custom recipes repository.
