### PR TITLE
Upgrade PHP version to 8.1 to match the required version in Symfony 6.3

### DIFF
--- a/bref/symfony-bridge/0.1/serverless.yaml
+++ b/bref/symfony-bridge/0.1/serverless.yaml
@@ -21,7 +21,7 @@ functions:
         handler: public/index.php
         timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
         layers:
-            - ${bref:layer.php-80-fpm}
+            - ${bref:layer.php-81-fpm}
         events:
             - httpApi: '*'
     # This function let us run console commands in Lambda
@@ -29,7 +29,7 @@ functions:
         handler: bin/console
         timeout: 120 # in seconds
         layers:
-            - ${bref:layer.php-80} # PHP
+            - ${bref:layer.php-81} # PHP
             - ${bref:layer.console} # The "console" layer
 
 package:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [https://packagist.org/packages/bref/symfony-bridge](https://packagist.org/packages/bref/symfony-bridge)

Since the last version of Symfony requires php8.1, I propose to match it in the config to avoid issues related to composer on deployment.

[https://github.com/symfony/symfony/blob/6.3/composer.json#L36](https://github.com/symfony/symfony/blob/6.3/composer.json#L36)
