### PR TITLE
Match install directions to actual filename for phpstan config file

### DIFF
--- a/phpstan/phpstan/1.0/post-install.txt
+++ b/phpstan/phpstan/1.0/post-install.txt
@@ -1,4 +1,4 @@
-  * Edit the <comment>phpstan.neon.dist</comment> file to configure PHPStan.
+  * Edit the <comment>phpstan.dist.neon</comment> file to configure PHPStan.
 
   * For the full options, see
     <comment>https://phpstan.org/user-guide/getting-started</comment>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Docs Issue/PR     | https://github.com/symfony/recipes-contrib/issues/1555

The file in the repo is `phpstan.dist.neon` but the text said `phpstan.neon.dist`.

According to the docs, either `phpstan.dist.neon` or `phpstan.neon.dist` are acceptable (see: https://phpstan.org/config-reference#config-file). I'm sticking with `phpstan.dist.neon` since text editors that recognize the `.neon` extension will render the contents of the file nicely.