### PR TITLE
Use SymLinksIfOwnerMatch by default.

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -9,7 +9,7 @@ DirectoryIndex index.php
 # feature in your server configuration. Uncomment the following line if you
 # install assets as symlinks or if you experience problems related to symlinks
 # when compiling LESS/Sass/CoffeScript assets.
-# Options +FollowSymlinks
+# Options +SymLinksIfOwnerMatch
 
 # Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
 # to the front controller "/index.php" but be rewritten to "/index.php/index".
@@ -20,7 +20,7 @@ DirectoryIndex index.php
 <IfModule mod_rewrite.c>
     # This Option needs to be enabled for RewriteRule, otherwise it will show an error like
     # 'Options FollowSymLinks or SymLinksIfOwnerMatch is off which implies that RewriteRule directive is forbidden'
-    Options +FollowSymlinks
+    Options +SymLinksIfOwnerMatch
 
     RewriteEngine On
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

`Options +SymLinksIfOwnerMatch` is more secure than `Options +FollowSymlinks`.

With the `FollowSymlinks` option enabled, you could easily mistakenly create a symlink to a file outside the web root folder and Apache would follow it. The owner of files for the web application usually differs from other system files. This additional owner check reduces the risk of exposing files.
