### PR TITLE
Add doctrine/mongodb-odm-bundle v5 without is_bundle (default to false)

### DIFF
--- a/doctrine/mongodb-odm-bundle/5.0/config/packages/doctrine_mongodb.yaml
+++ b/doctrine/mongodb-odm-bundle/5.0/config/packages/doctrine_mongodb.yaml
@@ -1,0 +1,31 @@
+doctrine_mongodb:
+    auto_generate_proxy_classes: true
+    auto_generate_hydrator_classes: true
+    connections:
+        default:
+            server: '%env(resolve:MONGODB_URL)%'
+            options: {}
+    default_database: '%env(resolve:MONGODB_DB)%'
+    document_managers:
+        default:
+            auto_mapping: true
+            mappings:
+                App:
+                    dir: '%kernel.project_dir%/src/Document'
+                    prefix: 'App\Document'
+
+when@prod:
+    doctrine_mongodb:
+        auto_generate_proxy_classes: false
+        auto_generate_hydrator_classes: false
+        document_managers:
+            default:
+                metadata_cache_driver:
+                    type: service
+                    id: doctrine_mongodb.system_cache_pool
+
+    framework:
+        cache:
+            pools:
+                doctrine_mongodb.system_cache_pool:
+                    adapter: cache.system

--- a/doctrine/mongodb-odm-bundle/5.0/manifest.json
+++ b/doctrine/mongodb-odm-bundle/5.0/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "Doctrine\\Bundle\\MongoDBBundle\\DoctrineMongoDBBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    },
+    "container": {
+        "env(MONGODB_URL)": "",
+        "env(MONGODB_DB)": ""
+    },
+    "env": {
+        "MONGODB_URL": "mongodb://localhost:27017",
+        "MONGODB_DB": "symfony"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [<!-- Link to package on packagist -->](https://packagist.org/packages/doctrine/mongodb-odm-bundle)

The `is_bundle` and `alias` configs are not required by default.