### PR TITLE
Update the Sentry recipe

### DIFF
--- a/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
@@ -5,7 +5,7 @@ when@prod:
         # automatic instrumentation (there might be some performance penalty)
         # https://docs.sentry.io/platforms/php/guides/symfony/performance/instrumentation/automatic-instrumentation/
         tracing:
-            enabled: true
+            enabled: false
 
 #        If you are using Monolog, you also need this additional configuration to log the errors correctly:
 #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration

--- a/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
@@ -1,6 +1,11 @@
 when@prod:
     sentry:
         dsn: '%env(SENTRY_DSN)%'
+        # this hooks into critical paths of the framework (and vendors) to perform
+        # automatic instrumentation (there might be some performance penalty)
+        # https://docs.sentry.io/platforms/php/guides/symfony/performance/instrumentation/automatic-instrumentation/
+        tracing:
+            enabled: true
 
 #        If you are using Monolog, you also need this additional configuration to log the errors correctly:
 #        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
@@ -13,3 +18,9 @@ when@prod:
 #                type: sentry
 #                level: !php/const Monolog\Logger::ERROR
 #                hub_id: Sentry\State\HubInterface
+
+#    Uncomment these lines to register a log message processor that resolves PSR-3 placeholders
+#    https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
+#    services:
+#        Monolog\Processor\PsrLogMessageProcessor:
+#            tags: { name: monolog.processor, handler: sentry }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sentry/sentry-symfony

Updated the recipe according to:

* https://docs.sentry.io/platforms/php/guides/symfony/performance/instrumentation/automatic-instrumentation/
* https://docs.sentry.io/platforms/php/guides/symfony/

~I know that `tracing.enabled: true` is the default option and we try to not add the default values to recipes to make them simpler. But this is a very important option that can impact the performance of your application, so I think it's fair to show this option prominently.~ Update: we set this option to `false` by default
