### PR TITLE
[dama/doctrine-test-bundle] Use when@ keyword

### DIFF
--- a/dama/doctrine-test-bundle/7.2/config/packages/dama_doctrine_test_bundle.yaml
+++ b/dama/doctrine-test-bundle/7.2/config/packages/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,5 @@
+when@test:
+    dama_doctrine_test:
+        enable_static_connection: true
+        enable_static_meta_data_cache: true
+        enable_static_query_cache: true

--- a/dama/doctrine-test-bundle/7.2/manifest.json
+++ b/dama/doctrine-test-bundle/7.2/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "DAMA\\DoctrineTestBundle\\DAMADoctrineTestBundle": ["test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "add-lines": [
+        {
+            "file": "phpunit.xml.dist",
+            "content": "        <extension class=\"DAMA\\DoctrineTestBundle\\PHPUnit\\PHPUnitExtension\" />",
+            "position": "after_target",
+            "target": "<extensions>",
+            "warn_if_missing": true
+        }
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/dama/doctrine-test-bundle

Symfony 5.3 introduced the `when@...` special key for configuring multiple environments in a single file. DAMADoctrineTestBundle 7.2 was the first version to only support Symfony 5.3 or newer, so it should be safe to create a new recipe for version 7.2.