### PR TITLE
Adjust JWT Refresh Token Bundle recipe to use attributes

### DIFF
--- a/gesdinet/jwt-refresh-token-bundle/1.0/src/Entity/RefreshToken.php
+++ b/gesdinet/jwt-refresh-token-bundle/1.0/src/Entity/RefreshToken.php
@@ -5,10 +5,8 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshToken as BaseRefreshToken;
 
-/**
- * @ORM\Entity
- * @ORM\Table("refresh_tokens")
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'refresh_tokens')]
 class RefreshToken extends BaseRefreshToken
 {
 }


### PR DESCRIPTION
Use attributes on the entity instead of annotations as they are fully removed from ORM 3.0 and no will longer work with new setups

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/gesdinet/jwt-refresh-token-bundle

