### PR TITLE
Replace Doctrine2 with Doctrine in Codeception recipe

### DIFF
--- a/codeception/codeception/5.0/tests/Functional.suite.yml
+++ b/codeception/codeception/5.0/tests/Functional.suite.yml
@@ -10,6 +10,6 @@ modules:
         - Symfony:
               app_path: 'src'
               environment: 'test'
-#        - Doctrine2:
+#        - Doctrine:
 #              depends: Symfony
 #              cleanup: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [codeception/codeception](https://packagist.org/packages/codeception/codeception)

https://github.com/Codeception/module-doctrine is the successor of https://github.com/Codeception/module-doctrine2

