### PR TITLE
Sentry Symfony SDK 5.0.0

### DIFF
--- a/sentry/sentry-symfony/5.0/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/5.0/config/packages/sentry.yaml
@@ -1,0 +1,25 @@
+when@prod:
+    sentry:
+        dsn: '%env(SENTRY_DSN)%'
+        options:
+            ignore_exceptions:
+                - 'Symfony\Component\ErrorHandler\Error\FatalError'
+                - 'Symfony\Component\Debug\Exception\FatalErrorException'
+
+#        If you are using Monolog, you also need this additional configuration to log the errors correctly:
+#        https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
+#        register_error_listener: false
+#        register_error_handler: false
+
+#    monolog:
+#        handlers:
+#            sentry:
+#                type: sentry
+#                level: !php/const Monolog\Logger::ERROR
+#                hub_id: Sentry\State\HubInterface
+
+#    Uncomment these lines to register a log message processor that resolves PSR-3 placeholders
+#    https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
+#    services:
+#        Monolog\Processor\PsrLogMessageProcessor:
+#            tags: { name: monolog.processor, handler: sentry }

--- a/sentry/sentry-symfony/5.0/manifest.json
+++ b/sentry/sentry-symfony/5.0/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "Sentry\\SentryBundle\\SentryBundle": ["prod"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "SENTRY_DSN": ""
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<5.4",
+        "symfony/monolog-bundle": "<3.7"
+    }
+}


### PR DESCRIPTION
Q | A
-- | --
License | MIT
Packagist | https://packagist.org/packages/sentry/sentry-symfony

We released a [new major version](https://github.com/getsentry/sentry-symfony/releases/tag/5.0.0) of our Sentry Symfony SDK.

