### PR TITLE
Added recipe for endeavour/groeigids-api-client-bundle

### DIFF
--- a/endeavour/groeigids-api-client-bundle/0.1/config/packages/groeigids_api_client.yaml
+++ b/endeavour/groeigids-api-client-bundle/0.1/config/packages/groeigids_api_client.yaml
@@ -1,0 +1,2 @@
+groeigids_api_client:
+    api_key: '%env(GROEIGIDS_API_KEY)%'

--- a/endeavour/groeigids-api-client-bundle/0.1/manifest.json
+++ b/endeavour/groeigids-api-client-bundle/0.1/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Endeavour\\GroeigidsApiClientBundle\\GroeigidsApiClientBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "GROEIGIDS_API_KEY": "your-groeigids-api-key"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/endeavour/groeigids-api-client-bundle

The "Run updated recipes" fails because the package does not support PHP 7.4, but works fine with PHP >= 8.1