### PR TITLE
Add qossmic/deptrac recipe

### DIFF
--- a/qossmic/deptrac/2.0/deptrac.yaml
+++ b/qossmic/deptrac/2.0/deptrac.yaml
@@ -1,0 +1,30 @@
+deptrac:
+    paths:
+        - ./src
+    exclude_files:
+        - '#.*test.*#'
+    layers:
+        -
+            name: Controller
+            collectors:
+                -
+                    type: classLike
+                    value: .*Controller.*
+        -
+            name: Repository
+            collectors:
+                -
+                    type: classLike
+                    value: .*Repository.*
+        -
+            name: Service
+            collectors:
+                -
+                    type: classLike
+                    value: .*Service.*
+    ruleset:
+        Controller:
+            - Service
+        Service:
+            - Repository
+        Repository:

--- a/qossmic/deptrac/2.0/manifest.json
+++ b/qossmic/deptrac/2.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "copy-from-recipe": {
+        "deptrac.yaml": "deptrac.yaml"
+    },
+    "gitignore": [
+        "/.deptrac.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [qossmic/deptrac](https://packagist.org/packages/qossmic/deptrac)

`qossmic/deptrac-shim` is deprecated and has been replaced by `qossmic/deptrac`.
