### PR TITLE
Add monsieurbiz/sylius-cms v1.0 by @MonsieurBiz

### DIFF
--- a/monsieurbiz/sylius-cms/1.0/manifest.json
+++ b/monsieurbiz/sylius-cms/1.0/manifest.json
@@ -1,0 +1,3 @@
+{
+    "aliases": ["sylius-cms"]
+}


### PR DESCRIPTION
The monsieurbiz/sylius-cms package is a metapackage that installs the following:

```json
{
    "monsieurbiz/sylius-cms-page-plugin": "^1.0",
    "monsieurbiz/sylius-homepage-plugin": "^1.1",
    "monsieurbiz/sylius-media-manager-plugin": "^1.0",
    "monsieurbiz/sylius-menu-plugin": "^1.3"
}
```

All those plugins have valid recipes in this repository.

We have specified the `sylius-cms` alias since this metapackage is exactly install CMS plugins for Sylius.