### PR TITLE
Update Sentry PSR3 information

### DIFF
--- a/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/4.6/config/packages/sentry.yaml
@@ -18,9 +18,5 @@ when@prod:
 #                type: sentry
 #                level: !php/const Monolog\Logger::ERROR
 #                hub_id: Sentry\State\HubInterface
-
-#    Uncomment these lines to register a log message processor that resolves PSR-3 placeholders
-#    https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
-#    services:
-#        Monolog\Processor\PsrLogMessageProcessor:
-#            tags: { name: monolog.processor, handler: sentry }
+#                fill_extra_context: true # Enables sending monolog context to Sentry
+#                process_psr_3_messages: false # Disables the resolution of PSR-3 placeholders

--- a/sentry/sentry-symfony/5.0/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/5.0/config/packages/sentry.yaml
@@ -17,9 +17,5 @@ when@prod:
 #                type: sentry
 #                level: !php/const Monolog\Logger::ERROR
 #                hub_id: Sentry\State\HubInterface
-
-#    Uncomment these lines to register a log message processor that resolves PSR-3 placeholders
-#    https://docs.sentry.io/platforms/php/guides/symfony/#monolog-integration
-#    services:
-#        Monolog\Processor\PsrLogMessageProcessor:
-#            tags: { name: monolog.processor, handler: sentry }
+#                fill_extra_context: true # Enables sending monolog context to Sentry
+#                process_psr_3_messages: false # Disables the resolution of PSR-3 placeholders


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sentry/sentry-symfony

There's no need to manually register the `PsrLogMessageProcessor`, this is done automatically since https://github.com/symfony/monolog-bundle/commit/8f0012305b01ebb81332ffa413edbb4352646b4b . It's enabled by default, but can be disabled by setting the `process_psr_3_messages` option to `false`.

I've also opened a PR in the Sentry docs repo: https://github.com/getsentry/sentry-docs/pull/11063

cc @javiereguiluz 