### PR TITLE
feat: add storage to auto for shopware app bundle

### DIFF
--- a/shopware/app-bundle/4.0/config/packages/shopware_app.yaml
+++ b/shopware/app-bundle/4.0/config/packages/shopware_app.yaml
@@ -1,7 +1,7 @@
 shopware_app:
     name: '%env(SHOPWARE_APP_NAME)%'
     secret: '%env(SHOPWARE_APP_SECRET)%'
-    # You should use doctrine or dynamodb as storage
-    storage: 'in-memory'
+    # You should specify a specific storage like: dynamodb or doctrine
+    storage: 'auto'
     doctrine:
         shop_class: App\Entity\Shop


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/shopware/app-bundle

Instead of using hard-code in-memory, we let auto detect the storage so it's more convenient for users to install
