### PR TITLE
Fix method switching

### DIFF
--- a/symfony/apache-pack/1.0/public/.htaccess
+++ b/symfony/apache-pack/1.0/public/.htaccess
@@ -50,7 +50,7 @@ DirectoryIndex index.php
     # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
     #   following RewriteCond (best solution)
     RewriteCond %{ENV:REDIRECT_STATUS} =""
-    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
+    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=308,L]
 
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [symfony/apache-pack](https://packagist.org/packages/symfony/apache-pack)

Fix method switching when the path starts with `/index.php` and `mod_rewrite` is available.

Related #165
