### PR TITLE
Add 21torr/task-manager

### DIFF
--- a/21torr/task-manager/2.0/config/packages/task_manager.yaml
+++ b/21torr/task-manager/2.0/config/packages/task_manager.yaml
@@ -1,0 +1,6 @@
+task_manager:
+    queues:
+        # queues sorted by priority. Highest priority at the top
+        - app_very_urgent
+        - app_urgent
+        - app

--- a/21torr/task-manager/2.0/manifest.json
+++ b/21torr/task-manager/2.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Torr\\TaskManager\\TaskManagerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/21torr/task-manager

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

For v2 it's only the default config file for now.
