### PR TITLE
remove php route config

### DIFF
--- a/survos/command-bundle/1.5/config/routes/survos_command.php
+++ b/survos/command-bundle/1.5/config/routes/survos_command.php
@@ -1,9 +1,0 @@
-<?php
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-
-return static function (RoutingConfigurator $routes): void {
-    $routes->import('@SurvosCommandBundle/config/routes.php')
-        ->prefix('/admin') // consider adding this path to the access_control key in security
-    ;
-};
-

--- a/survos/command-bundle/1.5/config/routes/survos_command.yaml
+++ b/survos/command-bundle/1.5/config/routes/survos_command.yaml
@@ -1,0 +1,6 @@
+survos_command:
+    prefix: /admin/commands
+    type: attribute
+    resource:
+        path: '@SurvosCommandBundle/src/Controller/'
+        namespace: Survos\CommandBundle\Controller

--- a/survos/command-bundle/1.5/post-install.txt
+++ b/survos/command-bundle/1.5/post-install.txt
@@ -4,5 +4,5 @@
 
   * <fg=yellow>Next steps:</>
     1. Configure /config/packages/survos_command.php to expose the namespaces (command prefixes)
-    2. <comment>secure the /admin route, configure the route in config/routes/survos_command.php</>;
-    3. Visit <comment>/admin/commmands</>.
+    2. <comment>secure the /admin route, configure the route in config/routes/survos_command.yaml</>;
+    3. Visit <href=/admin/commmands</>.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/survos/command-bundle

Updates the routing recipe to use YAML instead of php.