### PR TITLE
rename "database" service into "eventstore" to avoid conficts with doctrine

### DIFF
--- a/patchlevel/event-sourcing-bundle/3.0/manifest.json
+++ b/patchlevel/event-sourcing-bundle/3.0/manifest.json
@@ -18,7 +18,7 @@
     "docker-compose": {
         "docker-compose.yml": {
             "services": [
-                "database:",
+                "eventstore:",
                 "  image: postgres:${POSTGRES_VERSION:-16}-alpine",
                 "  environment:",
                 "    POSTGRES_DB: ${POSTGRES_DB:-app}",
@@ -26,15 +26,15 @@
                 "    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}",
                 "    POSTGRES_USER: ${POSTGRES_USER:-app}",
                 "  volumes:",
-                "    - database_data:/var/lib/postgresql/data:rw",
+                "    - eventstore_data:/var/lib/postgresql/data:rw",
                 "    # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!",
                 "    # - ./docker/db/data:/var/lib/postgresql/data:rw"
             ],
-            "volumes": ["database_data:"]
+            "volumes": ["eventstore_data:"]
         },
         "docker-compose.override.yml": {
             "services": [
-                "database:",
+                "eventstore:",
                 "  ports:",
                 "    - \"5432\""
             ]

--- a/patchlevel/event-sourcing-bundle/3.0/manifest.json
+++ b/patchlevel/event-sourcing-bundle/3.0/manifest.json
@@ -3,7 +3,8 @@
         "Patchlevel\\EventSourcingBundle\\PatchlevelEventSourcingBundle": ["all"]
     },
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
+        "config/": "%CONFIG_DIR%/",
+        "migrations/": "migrations/"
     },
     "env": {
         "#1": "Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/patchlevel/event-sourcing-bundle

If you use doctrine and event-sourcing recipes, you get a conflict in the docker-compose.yaml.

This is now avoided by giving the event store its own DB service. This also makes more sense, since it is usually not the same DB that you use for event-sourcing.