### PR TITLE
fix: default invalid key

### DIFF
--- a/fluffydiscord/roadrunner-symfony-bundle/3.0/config/packages/fluffy_discord_road_runner.yaml
+++ b/fluffydiscord/roadrunner-symfony-bundle/3.0/config/packages/fluffy_discord_road_runner.yaml
@@ -66,5 +66,6 @@ fluffy_discord_road_runner:
         keypair_path: bin/keypair.key
 
 when@dev:
-    fluffy_discord_road_runner:
-        early_router_initialization: false
+    http:
+        fluffy_discord_road_runner:
+            early_router_initialization: false

--- a/fluffydiscord/roadrunner-symfony-bundle/3.0/config/packages/fluffy_discord_road_runner.yaml
+++ b/fluffydiscord/roadrunner-symfony-bundle/3.0/config/packages/fluffy_discord_road_runner.yaml
@@ -66,6 +66,6 @@ fluffy_discord_road_runner:
         keypair_path: bin/keypair.key
 
 when@dev:
-    http:
-        fluffy_discord_road_runner:
+    fluffy_discord_road_runner:
+        http:
             early_router_initialization: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     |  https://packagist.org/packages/fluffydiscord/roadrunner-symfony-bundle