### PR TITLE
Add admin routes to Commerce Weavers Tpay plugin recipe

### DIFF
--- a/commerce-weavers/sylius-tpay-plugin/2.0/config/routes/commerce_weavers_tpay_plugin.yaml
+++ b/commerce-weavers/sylius-tpay-plugin/2.0/config/routes/commerce_weavers_tpay_plugin.yaml
@@ -6,3 +6,7 @@ commerce_weavers_sylius_tpay_shop:
     prefix: /{_locale}
     requirements:
         _locale: ^[A-Za-z]{2,4}(_([A-Za-z]{4}|[0-9]{3}))?(_([A-Za-z]{2}|[0-9]{3}))?$
+
+commerce_weavers_sylius_tpay_admin:
+    resource: "@CommerceWeaversSyliusTpayPlugin/config/routes_admin.php"
+    prefix: /admin


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [packagist.org/packages/commerce-weavers/sylius-tpay-plugin](https://packagist.org/packages/commerce-weavers/sylius-tpay-plugin)

The recipe is missing admin routes import.
