### PR TITLE
Fix post install message for JanePHP components

### DIFF
--- a/jane-php/json-schema/6.0/post-install.txt
+++ b/jane-php/json-schema/6.0/post-install.txt
@@ -2,7 +2,7 @@
     1. Configure <comment>config/jane/json_schema.php</> with your specification details
     2. Run <comment>bin/jane-json-schema-generate</>
     3. Add <comment>generated/</> directory to your composer autoload definition (eg. <comment>"MyApp\\Library\\Generated\\": "generated/"</>)
-    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\</> namespace with your generated namespace.
+    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated</> namespace with your generated namespace.
     5. Then remove line comments
 
 Documentation: https://jane.readthedocs.io/en/latest/

--- a/jane-php/json-schema/7.0/post-install.txt
+++ b/jane-php/json-schema/7.0/post-install.txt
@@ -2,7 +2,7 @@
     1. Configure <comment>config/jane/json_schema.php</> with your specification details
     2. Run <comment>bin/jane-json-schema-generate</>
     3. Add <comment>generated/</> directory to your composer autoload definition (eg. <comment>"MyApp\\Library\\Generated\\": "generated/"</>)
-    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\</> namespace with your generated namespace.
+    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated</> namespace with your generated namespace.
     5. Then remove line comments
 
 Documentation: https://jane.readthedocs.io/en/latest/

--- a/jane-php/open-api-common/6.0/post-install.txt
+++ b/jane-php/open-api-common/6.0/post-install.txt
@@ -2,7 +2,7 @@
     1. Configure <comment>config/jane/open_api.php</> with your specification details
     2. Run <comment>bin/jane-open-api-generate</>
     3. Add <comment>generated/</> directory to your composer autoload definition (eg. <comment>"MyApp\\Library\\Generated\\": "generated/"</>)
-    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\</> namespace with your generated namespace.
+    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated</> namespace with your generated namespace.
     5. Then remove line comments
 
 Documentation: https://jane.readthedocs.io/en/latest/

--- a/jane-php/open-api-common/7.0/post-install.txt
+++ b/jane-php/open-api-common/7.0/post-install.txt
@@ -2,7 +2,7 @@
     1. Configure <comment>config/jane/open_api.php</> with your specification details
     2. Run <comment>bin/jane-open-api-generate</>
     3. Add <comment>generated/</> directory to your composer autoload definition (eg. <comment>"MyApp\\Library\\Generated\\": "generated/"</>)
-    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated\</> namespace with your generated namespace.
+    4. Open <comment>config/packages/jane.yaml</> and replace <comment>MyApp\Library\Generated</> namespace with your generated namespace.
     5. Then remove line comments
 
 Documentation: https://jane.readthedocs.io/en/latest/


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/jane-php/json-schema https://packagist.org/packages/jane-php/open-api-3

There was a `\` in front of a `</>` which was breaking coloration. This PR is fixing this issue.