### PR TITLE
Fix kunstmaan/seo-bundle route config for 7.3 version

### DIFF
--- a/kunstmaan/seo-bundle/7.3/config/routes/kunstmaan_seo.yaml
+++ b/kunstmaan/seo-bundle/7.3/config/routes/kunstmaan_seo.yaml
@@ -1,0 +1,11 @@
+KunstmaanSeoBundle:
+    resource: "@KunstmaanSeoBundle/Resources/config/routing.yml"
+    # If your site is not multi language, remove the "{_locale}/" part of prefix and requirements
+    prefix: /{_locale}/
+    requirements:
+        _locale: "%kunstmaan_admin.required_locales%"
+
+# Robots.txt
+KunstmaanSeoBundle_robots:
+    resource: "@KunstmaanSeoBundle/Controller/RobotsController.php"
+    type: attribute

--- a/kunstmaan/seo-bundle/7.3/manifest.json
+++ b/kunstmaan/seo-bundle/7.3/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Kunstmaan\\SeoBundle\\KunstmaanSeoBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/kunstmaan/seo-bundle

In the upcoming 7.3 version the route config in the controller is switched to attributes


