### PR TITLE
Add recipe for devzair/mail-logger-bundle 1.0

### DIFF
--- a/devzair/mail-logger-bundle/1.0/config/packages/mail_logger.yaml
+++ b/devzair/mail-logger-bundle/1.0/config/packages/mail_logger.yaml
@@ -1,0 +1,2 @@
+mail_logger:
+    enabled: true

--- a/devzair/mail-logger-bundle/1.0/manifest.json
+++ b/devzair/mail-logger-bundle/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "DevZair\\MailLoggerBundle\\MailLoggerBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
This PR adds a Symfony Flex recipe for the package devzair/mail-logger-bundle.
It provides automatic configuration and bundle registration.

Files added:
- config/packages/mail_logger.yaml
- manifest.json

The bundle allows automatic logging of all emails sent via Symfony Mailer.
