### PR TITLE
Add recipe for gurtok/seo-bundle

### DIFF
--- a/gurtok/seo-bundle/1.0/config/packages/gurtok_seo.yaml
+++ b/gurtok/seo-bundle/1.0/config/packages/gurtok_seo.yaml
@@ -1,0 +1,6 @@
+gurtok_seo:
+    allow_custom_meta: false
+    auto_inject_response: false
+    excluded_paths:
+#        - /admin
+#        - /api

--- a/gurtok/seo-bundle/1.0/config/packages/gurtok_seo.yaml
+++ b/gurtok/seo-bundle/1.0/config/packages/gurtok_seo.yaml
@@ -1,6 +1,9 @@
 gurtok_seo:
+    # this switch off validation of meta tags (other case will be validated by MetaTag enum)
     allow_custom_meta: false
+    # this switch on auto inject of meta tags in response
     auto_inject_response: false
+    # this parameter is used to exclude some paths from auto inject of seo response
     excluded_paths:
 #        - /admin
 #        - /api

--- a/gurtok/seo-bundle/1.0/manifest.json
+++ b/gurtok/seo-bundle/1.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Gurtok\\SeoBundle\\SeoBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "conflict": {
+        "php": "<8.1"
+    }
+}

--- a/gurtok/seo-bundle/1.0/manifest.json
+++ b/gurtok/seo-bundle/1.0/manifest.json
@@ -1,6 +1,6 @@
 {
     "bundles": {
-        "Gurtok\\SeoBundle\\SeoBundle": ["all"]
+        "Gurtok\\SeoBundle\\GurtokSeoBundle": ["all"]
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"

--- a/gurtok/seo-bundle/1.0/manifest.json
+++ b/gurtok/seo-bundle/1.0/manifest.json
@@ -6,6 +6,7 @@
         "config/": "%CONFIG_DIR%/"
     },
     "conflict": {
-        "php": "<8.1"
+        "php": "<8.1",
+        "symfony/framework-bundle": "<6.0"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/gurtok/seo-bundle



<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

This recipe provides default configuration for Gurtok SeoBundle,
a flexible SEO metadata manager for Symfony 6/7.

✅ Automatically registers the bundle  
✅ Creates `config/packages/gurtok_seo.yaml` with default settings  
