### PR TITLE
feat(keron-digital/auth-redis-storage-bundle): Add recipe for v1.0

### DIFF
--- a/keron-digital/auth-redis-storage-bundle/1.0/config/packages/keron_digital_auth_redis_storage.yaml
+++ b/keron-digital/auth-redis-storage-bundle/1.0/config/packages/keron_digital_auth_redis_storage.yaml
@@ -1,0 +1,21 @@
+# config/packages/keron_digital_auth_redis_storage.yaml
+# Copied by Symfony Flex recipe.
+keron_digital_auth_redis_storage:
+  # !!! REQUIRED: Specify your application's Redis client service ID below. !!!
+  # Find the correct service ID using 'bin/console debug:container | grep Redis' or similar.
+  # Examples: 'snc_redis.default', 'cache.app.redis', '\Redis', etc.
+  redis_client_service_id: 'CHANGE_ME_redis_service_id'
+
+  # --- Optional configuration with defaults ---
+  # Uncomment and change if needed:
+  #
+  # General prefix for all Redis keys used by the bundle
+  # key_prefix: 'auth:'
+  #
+  # Configuration for the blacklist service
+  # blacklist:
+  #     key_suffix: 'bl:' # Example key: auth:bl:<token_id>
+  #
+  # Configuration for the active token storage service
+  # active_token_storage:
+  #     key_suffix: 'active:' # Example key: auth:active:<token_id>

--- a/keron-digital/auth-redis-storage-bundle/1.0/manifest.json
+++ b/keron-digital/auth-redis-storage-bundle/1.0/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest": {
+    "copy-from-recipe": {
+      "config/": "%CONFIG_DIR%/"
+    }
+  },
+  "bundles": {
+    "KeronDigital\\AuthRedisStorageBundle\\KeronDigitalAuthRedisStorageBundle": ["all"]
+  }
+}

--- a/keron-digital/auth-redis-storage-bundle/post-install-output.txt
+++ b/keron-digital/auth-redis-storage-bundle/post-install-output.txt
@@ -1,0 +1,7 @@
+<bg=blue;fg=white> KeronDigitalAuthRedisStorageBundle </>
+
+<fg=green>Bundle installed successfully!</>
+
+<fg=yellow>IMPORTANT:</> Please open the file <fg=cyan>config/packages/keron_digital_auth_redis_storage.yaml</>
+          and set the required <fg=cyan>redis_client_service_id</> option to point
+          to your application's Redis client service.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/keron-digital/auth-redis-storage-bundle

Hi maintainers,

This PR adds a Symfony Flex recipe for the `keron-digital/auth-redis-storage-bundle` package, covering version `^1.0.0`.

**Bundle Description:**
The bundle provides Redis-based infrastructure services for Symfony applications to manage token state, specifically focusing on:
* Token Blacklisting (using unique token identifiers like JTI or UUIDs)
* Active Token Tracking (marking tokens as valid until explicitly revoked or expired naturally)

**Links:**
* **GitHub Repository:** https://github.com/keron-digital/symfony-auth-redis-storage-bundle
* **Packagist:** https://packagist.org/packages/keron-digital/auth-redis-storage-bundle

**Recipe Details:**
* Copies a default configuration file (`config/packages/keron_digital_auth_redis_storage.yaml`) prompting the user to configure the required `redis_client_service_id`.
* Registers the `KeronDigital\AuthRedisStorageBundle\KeronDigitalAuthRedisStorageBundle` in `config/bundles.php` for all environments.
* Includes an optional `post-install-output.txt` message to guide the user.

Please, let me know if any changes are needed.

Thanks!
