### PR TITLE
Copy (and clean) recipes from `qossmic/deptrac` to `deptrac/deptrac`

### DIFF
--- a/deptrac/deptrac/3.0/deptrac.yaml
+++ b/deptrac/deptrac/3.0/deptrac.yaml
@@ -1,0 +1,30 @@
+deptrac:
+    paths:
+        - ./src
+    exclude_files:
+        - '#.*test.*#'
+    layers:
+        -
+            name: Controller
+            collectors:
+                -
+                    type: classLike
+                    value: .*Controller.*
+        -
+            name: Repository
+            collectors:
+                -
+                    type: classLike
+                    value: .*Repository.*
+        -
+            name: Service
+            collectors:
+                -
+                    type: classLike
+                    value: .*Service.*
+    ruleset:
+        Controller:
+            - Service
+        Service:
+            - Repository
+        Repository:

--- a/deptrac/deptrac/3.0/manifest.json
+++ b/deptrac/deptrac/3.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "copy-from-recipe": {
+        "deptrac.yaml": "deptrac.yaml"
+    },
+    "gitignore": [
+        "/.deptrac.cache"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/deptrac/deptrac

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

The package's organization has been renamed from `qossmic` to `deptrac` in https://github.com/deptrac/deptrac/releases/tag/3.0.0, meaning the actual recipe does not apply when moving from the new package
