### PR TITLE
Add recipe for djdmg/transparent-pixel-bundle (v1.0.1)

### DIFF
--- a/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
+++ b/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
@@ -1,0 +1,3 @@
+transparent_pixel_bundle:
+  resource: '@TransparentPixelBundle/Controller/'
+  type: attribute

--- a/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
+++ b/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
@@ -1,3 +1,3 @@
 transparent_pixel_bundle:
-  resource: '@TransparentPixelBundle/Controller/'
-  type: attribute
+    resource: '@TransparentPixelBundle/Controller/'
+    type: attribute

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 1,
+  "bundles": {
+    "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
+  },
+  "copy-from-recipe": {
+    "config/": "%CONFIG_DIR%/"
+  },
+  "post-install-output": [
+    "TransparentPixelBundle ready.",
+    "Routes imported at config/routes/transparent_pixel.yaml",
+    "Next steps:",
+    "  - bin/console doctrine:migrations:diff",
+    "  - bin/console doctrine:migrations:migrate -n"
+  ]
+}

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,15 +1,15 @@
 {
-  "bundles": {
-    "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
-  },
-  "copy-from-recipe": {
-    "config/": "%CONFIG_DIR%/"
-  },
-  "post-install-output": [
-    "TransparentPixelBundle ready.",
-    "Routes imported at config/routes/transparent_pixel.yaml",
-    "Next steps:",
-    "  - bin/console doctrine:migrations:diff",
-    "  - bin/console doctrine:migrations:migrate -n"
-  ]
+    "bundles": {
+        "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "post-install-output": [
+        "TransparentPixelBundle ready.",
+        "Routes imported at config/routes/transparent_pixel.yaml",
+        "Next steps:",
+        "  - bin/console doctrine:migrations:diff",
+        "  - bin/console doctrine:migrations:migrate -n"
+    ]
 }

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,5 +1,4 @@
 {
-  "manifest_version": 1,
   "bundles": {
     "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
   },


### PR DESCRIPTION


| Field      | Value                                                                                 |
|------------|---------------------------------------------------------------------------------------|
| Package    | djdmg/transparent-pixel-bundle                                                        |
| Type       | symfony-bundle                                                                        |
| Purpose    | Provide a 1×1 transparent tracking pixel for Symfony (pages & emails)                 |
| Packagist  | https://packagist.org/packages/djdmg/transparent-pixel-bundle                         |
| Repository | https://github.com/djdmg/transparent-pixel-bundle                                     |
| License    | MIT                                                                                   |

## Summary
This PR adds a Symfony Flex **contrib recipe** for `djdmg/transparent-pixel-bundle`.  
The recipe wires the bundle automatically and imports its attribute routes so users can start immediately after `composer require`.

## What the recipe does
- Registers `Djdmg\TransparentPixelBundle\TransparentPixelBundle` in `config/bundles.php` (all envs).
- Copies `config/routes/transparent_pixel.yaml` that imports `@TransparentPixelBundle/Controller/` (attribute routing).

## Files added by this recipe
- `djdmg/transparent-pixel-bundle/1.0/manifest.json`
- `djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml`

### `manifest.json` (for reference)
```json
{
  "manifest_version": 1,
  "bundles": {
    "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
  },
  "copy-from-recipe": {
    "config/": "%CONFIG_DIR%/"
  },
  "post-install-output": [
    "TransparentPixelBundle ready.",
    "Routes imported at config/routes/transparent_pixel.yaml",
    "Next steps:",
    "  - bin/console doctrine:migrations:diff",
    "  - bin/console doctrine:migrations:migrate -n"
  ]
}