### PR TITLE
Feature/transparent pixel bundle 1.0

### DIFF
--- a/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
+++ b/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
@@ -1,0 +1,3 @@
+transparent_pixel_bundle:
+  resource: '@TransparentPixelBundle/Controller/'
+  type: attribute

--- a/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
+++ b/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
@@ -1,3 +1,3 @@
 transparent_pixel_bundle:
-  resource: '@TransparentPixelBundle/Controller/'
-  type: attribute
+    resource: '@TransparentPixelBundle/Controller/'
+    type: attribute

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 1,
+  "bundles": {
+    "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
+  },
+  "copy-from-recipe": {
+    "config/": "%CONFIG_DIR%/"
+  },
+  "post-install-output": [
+    "TransparentPixelBundle ready.",
+    "Routes imported at config/routes/transparent_pixel.yaml",
+    "Next steps:",
+    "  - bin/console doctrine:migrations:diff",
+    "  - bin/console doctrine:migrations:migrate -n"
+  ]
+}

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,15 +1,15 @@
 {
-  "bundles": {
-    "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
-  },
-  "copy-from-recipe": {
-    "config/": "%CONFIG_DIR%/"
-  },
-  "post-install-output": [
-    "TransparentPixelBundle ready.",
-    "Routes imported at config/routes/transparent_pixel.yaml",
-    "Next steps:",
-    "  - bin/console doctrine:migrations:diff",
-    "  - bin/console doctrine:migrations:migrate -n"
-  ]
+    "bundles": {
+        "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "post-install-output": [
+        "TransparentPixelBundle ready.",
+        "Routes imported at config/routes/transparent_pixel.yaml",
+        "Next steps:",
+        "  - bin/console doctrine:migrations:diff",
+        "  - bin/console doctrine:migrations:migrate -n"
+    ]
 }

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,5 +1,4 @@
 {
-  "manifest_version": 1,
   "bundles": {
     "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
   },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/djdmg/transparent-pixel-bundle

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

# Add recipe for djdmg/transparent-pixel-bundle (v1.0.1)

**Package:** `djdmg/transparent-pixel-bundle`  
**Type:** `symfony-bundle`

## Summary
Add a Symfony Flex **contrib recipe** for `djdmg/transparent-pixel-bundle`, targeting bundle **v1.0.1**.  
The bundle provides a 1×1 transparent tracking pixel; each hit stores IP/UA/OS/browser/device/mobile/bot/headers/query/cookies/referer/method/timestamp.

## What the recipe does
- Registers `Djdmg\TransparentPixelBundle\TransparentPixelBundle` in `config/bundles.php` (all envs).
- Copies `config/routes/transparent_pixel.yaml` that imports `@TransparentPixelBundle/Controller/` (attribute routes).

## Files added
- `djdmg/transparent-pixel-bundle/1.0/manifest.json`
- `djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml`

## Notes
- Recipe folder uses version **1.0/** (required `x.y` format for recipes), while the package version is **v1.0.1**.
- JSON/YAML use **4-space** indentation and only supported keys (no `manifest_version`).

## How to test
1. New Symfony 7 project.  
2. `composer config extra.symfony.allow-contrib true`  
3. `composer clear-cache`  
4. `composer require djdmg/transparent-pixel-bundle:^1.0 -n` (resolves to v1.0.1)  
5. Verify: bundle registered, routes file copied, `bin/console debug:router` shows `transparent_pixel_*`.  
6. Run Doctrine migrations in the app.