### PR TITLE
Add recipe for djdmg/transparent-pixel-bundle (1.0)

### DIFF
--- a/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
+++ b/djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml
@@ -1,0 +1,3 @@
+transparent_pixel_bundle:
+    resource: '@TransparentPixelBundle/Controller/'
+    type: attribute

--- a/djdmg/transparent-pixel-bundle/1.0/manifest.json
+++ b/djdmg/transparent-pixel-bundle/1.0/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "Djdmg\\TransparentPixelBundle\\TransparentPixelBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "post-install-output": [
+        "TransparentPixelBundle ready.",
+        "Routes imported at config/routes/transparent_pixel.yaml",
+        "Next steps:",
+        "  - bin/console doctrine:migrations:diff",
+        "  - bin/console doctrine:migrations:migrate -n"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/djdmg/transparent-pixel-bundle

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->

# Add recipe for djdmg/transparent-pixel-bundle (1.0)

**Package:** `djdmg/transparent-pixel-bundle`  
**Type:** `symfony-bundle`

## Summary
The recipe registers the bundle and imports attribute routes so users can start right after `composer require`.

## Files
- `djdmg/transparent-pixel-bundle/1.0/manifest.json`
- `djdmg/transparent-pixel-bundle/1.0/config/routes/transparent_pixel.yaml`
