### PR TITLE
[calliostro/last-fm-client-bundle] Add recipe

### DIFF
--- a/calliostro/last-fm-client-bundle/1.0/config/calliostro_last_fm_client.yaml
+++ b/calliostro/last-fm-client-bundle/1.0/config/calliostro_last_fm_client.yaml
@@ -1,0 +1,11 @@
+calliostro_last_fm_client:
+    # Get your API credentials from https://www.last.fm/api/account/create
+    api_key: '%env(LASTFM_API_KEY)%'
+    secret: '%env(LASTFM_SECRET)%'
+
+    # Optional: session key for user-specific actions (scrobbling, etc.)
+    # session: '%env(LASTFM_SESSION_KEY)%'
+
+    # Optional: HTTP client configuration
+    # http_client_options:
+    #     timeout: 30

--- a/calliostro/last-fm-client-bundle/1.0/manifest.json
+++ b/calliostro/last-fm-client-bundle/1.0/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "Calliostro\\LastFmClientBundle\\CalliostroLastFmClientBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "LASTFM_API_KEY": "",
+        "LASTFM_SECRET": "",
+        "#LASTFM_SESSION_KEY": ""
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/calliostro/last-fm-client-bundle

This adds a recipe for the calliostro/last-fm-client-bundle package.

The recipe:
- Registers the bundle in config/bundles.php
- Creates a configuration file with sensible defaults
- Adds necessary environment variables to .env

The recipe supports version 1.0+.

Package: https://packagist.org/packages/calliostro/last-fm-client-bundle
Repository: https://github.com/calliostro/last-fm-client-bundle