### PR TITLE
Add Discogs Bundle recipe v4.0

### DIFF
--- a/calliostro/discogs-bundle/4.0/config/calliostro_discogs.yaml
+++ b/calliostro/discogs-bundle/4.0/config/calliostro_discogs.yaml
@@ -1,0 +1,17 @@
+calliostro_discogs:
+    # Recommended: Personal Access Token (get from https://www.discogs.com/settings/developers)
+    # personal_access_token: '%env(DISCOGS_PERSONAL_ACCESS_TOKEN)%'
+    
+    # Alternative: Consumer credentials for OAuth applications
+    # Get from https://www.discogs.com/applications
+    # consumer_key: '%env(DISCOGS_CONSUMER_KEY)%'
+    # consumer_secret: '%env(DISCOGS_CONSUMER_SECRET)%'
+    
+    # Optional: HTTP User-Agent header for API requests
+    # Default: 'DiscogsClient/4.0.0 (+https://github.com/calliostro/php-discogs-api)'
+    # user_agent: 'MyApp/1.0 +https://myapp.com'
+    
+    # Optional: Rate limiting configuration (default values shown)
+    # throttle:
+    #     enabled: true
+    #     microseconds: 1000000  # 1 second delay between requests

--- a/calliostro/discogs-bundle/4.0/config/calliostro_discogs.yaml
+++ b/calliostro/discogs-bundle/4.0/config/calliostro_discogs.yaml
@@ -1,16 +1,16 @@
 calliostro_discogs:
     # Recommended: Personal Access Token (get from https://www.discogs.com/settings/developers)
     # personal_access_token: '%env(DISCOGS_PERSONAL_ACCESS_TOKEN)%'
-    
+
     # Alternative: Consumer credentials for OAuth applications
     # Get from https://www.discogs.com/applications
     # consumer_key: '%env(DISCOGS_CONSUMER_KEY)%'
     # consumer_secret: '%env(DISCOGS_CONSUMER_SECRET)%'
-    
+
     # Optional: HTTP User-Agent header for API requests
     # Default: 'DiscogsClient/4.0.0 (+https://github.com/calliostro/php-discogs-api)'
     # user_agent: 'MyApp/1.0 +https://myapp.com'
-    
+
     # Optional: Rate limiting configuration (default values shown)
     # throttle:
     #     enabled: true

--- a/calliostro/discogs-bundle/4.0/manifest.json
+++ b/calliostro/discogs-bundle/4.0/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "Calliostro\\DiscogsBundle\\CalliostroDiscogsBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#DISCOGS_PERSONAL_ACCESS_TOKEN": "",
+        "#DISCOGS_CONSUMER_KEY": "",
+        "#DISCOGS_CONSUMER_SECRET": ""
+    }
+}


### PR DESCRIPTION
- Add recipe for calliostro/discogs-bundle v4.0
- Supports Personal Access Token and OAuth authentication
- Includes configuration options with detailed comments
- Symfony bundle for Discogs API integration

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/calliostro/discogs-bundle

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->