### PR TITLE
Add configuration, routes, and manifest for LiquidRazor DTO API Bundle

### DIFF
--- a/liquidrazor/dto-api-bundle/0.1/config/packages/liquidrazor_dto_api.yaml
+++ b/liquidrazor/dto-api-bundle/0.1/config/packages/liquidrazor_dto_api.yaml
@@ -1,0 +1,13 @@
+# Default, safe config
+liquidrazor_dto_api:
+    normalizer_priority: 10
+    strict_types: true
+    # Use '3.0.3' if you need max Redoc OSS compatibility
+    openapi_version: '3.1.0'
+    default_responses:
+        422:
+            class: LiquidRazor\DtoApiBundle\Response\ValidationErrorResponse
+            description: 'Validation error'
+        500:
+            class: LiquidRazor\DtoApiBundle\Response\ErrorResponse
+            description: 'Server error'

--- a/liquidrazor/dto-api-bundle/0.1/config/routes/liquidrazor_dto_api.yaml
+++ b/liquidrazor/dto-api-bundle/0.1/config/routes/liquidrazor_dto_api.yaml
@@ -1,0 +1,4 @@
+# Wire the auto-docs + schema + listener routes from the bundle
+liquidrazor_dto_api:
+    resource: '@LiquidRazorDtoApiBundle/Resources/config/routes.php'
+    prefix: /

--- a/liquidrazor/dto-api-bundle/0.1/manifest.json
+++ b/liquidrazor/dto-api-bundle/0.1/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "LiquidRazor\\DtoApiBundle\\LiquidRazorDtoApiBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "post-install-output": [
+        "✅ LiquidRazor DTO API bundle installed.",
+        "Docs: /_docs/swagger  •  /_docs/redoc",
+        "OpenAPI: /_schema/openapi.json",
+        "Config: config/packages/liquidrazor_dto_api.yaml (edit defaults as you wish).",
+        "Routes were added via config/routes/liquidrazor_dto_api.yaml."
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/liquidrazor/dto-api-bundle

This adds a Symfony Flex recipe for `liquidrazor/dto-api-bundle`.

Package: https://packagist.org/packages/liquidrazor/dto-api-bundle
Minimum version: 0.1
Type: symfony-bundle

What the recipe does:
- Enables `LiquidRazor\DtoApiBundle\LiquidRazorDtoApiBundle` for all envs.
- Drops default config at `config/packages/liquidrazor_dto_api.yaml`.
- Registers routes at `config/routes/liquidrazor_dto_api.yaml` pointing to the bundle's route resource.

Out-of-the-box endpoints exposed by the bundle:
- `/_schema/openapi.json`
- `/_docs/swagger`
- `/_docs/redoc`

Tested on a fresh Symfony 7 skeleton by requiring the package and verifying the endpoints.
