### PR TITLE
Add recipe for atoum/atoum-bundle

### DIFF
--- a/atoum/atoum-bundle/7.0/.atoum.php
+++ b/atoum/atoum-bundle/7.0/.atoum.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This is the project's atoum configuration file.
+ * You can find more information about atoum configuration at:
+ * https://github.com/atoum/atoum
+ */
+
+use atoum\atoum;
+
+$script->addDefaultArguments(
+    // Enable code coverage (optional, comment out if you don't need it)
+    // '--enable-branch-and-path-coverage',
+    
+    // Test directories (adjust as needed)
+    '--directories', 'tests/Units',
+    
+    // Use the Symfony container for dependency injection
+    '--bootstrap-file', 'vendor/autoload.php'
+);
+
+// Configure test runner
+$runner->addTestsFromDirectory(__DIR__ . '/tests/Units');
+
+// CLI Report
+$cliReport = $script->addDefaultReport();
+
+// Code coverage report (HTML)
+if (getenv('GENERATE_COVERAGE') === 'true') {
+    $coverageField = new atoum\report\fields\runner\coverage\html(
+        'atoum', 
+        __DIR__ . '/var/coverage'
+    );
+    $coverageReport = new atoum\reports\coverage\html();
+    $coverageReport->addField($coverageField);
+    $runner->addReport($coverageReport);
+}

--- a/atoum/atoum-bundle/7.0/config/packages/test/atoum.yaml
+++ b/atoum/atoum-bundle/7.0/config/packages/test/atoum.yaml
@@ -1,0 +1,15 @@
+# Modern Symfony 7+ Approach (Recommended):
+# No configuration needed! Just use --directory option:
+#   bin/console atoum --directory=tests
+#   bin/console atoum --directory=src/Tests
+#   bin/console atoum --directory=tests/Unit --directory=tests/Integration
+
+# Legacy Bundle-based Approach (Still Supported):
+# Uncomment and configure if you need bundle-based testing:
+#atoum_atoum:
+#    bundles:
+#        YourVendor\YourBundle:
+#            directories:
+#                - Tests/Units
+#                - Tests/Controller
+#                - Tests/Functional

--- a/atoum/atoum-bundle/7.0/manifest.json
+++ b/atoum/atoum-bundle/7.0/manifest.json
@@ -1,0 +1,14 @@
+{
+    "bundles": {
+        "atoum\\AtoumBundle\\AtoumAtoumBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        ".atoum.php": ".atoum.php"
+    },
+    "gitignore": [
+        "/.atoum.php"
+    ]
+}
+
+

--- a/atoum/atoum-bundle/7.0/post-install.txt
+++ b/atoum/atoum-bundle/7.0/post-install.txt
@@ -1,0 +1,18 @@
+<bg=blue;fg=white>              </>
+<bg=blue;fg=white> What's next? </>
+<bg=blue;fg=white>              </>
+
+  * <fg=blue>✨ New in 3.0: Modern directory testing</> (no configuration needed!)
+    <comment>php bin/console atoum --directory=tests</>
+    <comment>php bin/console atoum --directory=src/Tests</>
+  
+  * <fg=blue>Create your first test</> extending <comment>atoum\AtoumBundle\Test\Units\Test</>
+  
+  * <fg=blue>Legacy bundle testing</> still works: <comment>php bin/console atoum YourBundle</>
+    Configure bundles in <comment>config/packages/test/atoum.yaml</> if needed
+  
+  * <fg=blue>For web tests</>, extend <comment>atoum\AtoumBundle\Test\Units\WebTestCase</>
+  
+  * <fg=blue>Read the upgrade guide</> at <comment>UPGRADE-3.0.md</>
+  
+  * <fg=blue>Documentation</> at <comment>https://github.com/atoum/AtoumBundle</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/atoum/atoum-bundle

## Package

- Package name: `atoum/atoum-bundle`
- Repository: https://github.com/atoum/AtoumBundle
- Packagist: https://packagist.org/packages/atoum/atoum-bundle

## Recipe Versions

- **2.0**: For Symfony 6 and earlier (PHP 7.4+)
- **3.0**: For Symfony 7+ (PHP 8.0+)

## What does this recipe do?

This recipe automates the setup of the AtoumBundle, which integrates the atoum testing framework with Symfony:

1. **Registers the bundle** in `config/bundles.php` for dev and test environments
2. **Creates default configuration** at `config/packages/test/atoum.yaml`
3. **Copies `.atoum.php`** configuration file to project root
4. **Adds `.atoum.php` to `.gitignore`**
5. **Displays helpful post-installation instructions**

## Key Features

### Version 3.0 (Modern Symfony 7+)
- ✨ **Zero-config approach**: No YAML configuration needed for modern directory testing
- 🎯 **Directory-based testing**: `bin/console atoum --directory=tests`
- 📚 Backward compatible with bundle-based testing

### Version 2.0 (Symfony 6 and earlier)
- 📦 **Bundle-based configuration**: Traditional Symfony approach
- 🔧 YAML configuration for bundle testing