### PR TITLE
Add recipe for planetpay/sylius-payment-plugin

### DIFF
--- a/planetpay/sylius-payment-plugin/1.0/config/packages/planetpay_sylius.yaml
+++ b/planetpay/sylius-payment-plugin/1.0/config/packages/planetpay_sylius.yaml
@@ -1,0 +1,2 @@
+imports:
+  - { resource: "@PlanetPaySyliusPaymentPlugin/config/config.yaml" }

--- a/planetpay/sylius-payment-plugin/1.0/config/routes/sylius_planetpay.yaml
+++ b/planetpay/sylius-payment-plugin/1.0/config/routes/sylius_planetpay.yaml
@@ -1,0 +1,2 @@
+sylius_planetpay:
+    resource: "@PlanetPaySyliusPaymentPlugin/config/routes.yaml"

--- a/planetpay/sylius-payment-plugin/1.0/manifest.json
+++ b/planetpay/sylius-payment-plugin/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+  "bundles": {
+    "PlanetPay\\SyliusPaymentPlugin\\PlanetPaySyliusPaymentPlugin": ["all"]
+  },
+  "copy-from-recipe": {
+    "config/": "%CONFIG_DIR%/"
+  }
+}


### PR DESCRIPTION
This recipe registers the PlanetPaySyliusPaymentPlugin bundle and imports configuration and routes.

Includes:
- Bundle registration
- Package config import
- Route import

Tested on Sylius 2.0
