### PR TITLE
Remove unneeded config file for `ajgarlag/openid-connect-provider-bundle`

### DIFF
--- a/ajgarlag/openid-connect-provider-bundle/0.2/config/packages/ajgarlag_openid_connect_provider.yaml
+++ b/ajgarlag/openid-connect-provider-bundle/0.2/config/packages/ajgarlag_openid_connect_provider.yaml
@@ -1,8 +1,0 @@
-ajgarlag_openid_connect_provider:
-    discovery:
-        authorization_endpoint_route: 'oauth2_authorize'
-        token_endpoint_route: 'oauth2_token'
-        jwks_endpoint_route: 'openid_connect_jwks'
-        end_session_endpoint_route: 'openid_connect_end_session'
-    end_session:
-        cancel_logout_default_path: '/'


### PR DESCRIPTION
All configured options currently match their default values.

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [ajgarlag/openid-connect-provider-bundle](https://packagist.org/packages/ajgarlag/openid-connect-provider-bundle)

The file `config/packages/ajgarlag_openid_connect_provider.yaml` can be safely removed, as all configured options currently match their default values.

See #1967 
