### PR TITLE
Add recipe for pascualmg/symfony-command-ui 1.0

### DIFF
--- a/pascualmg/symfony-command-ui/1.0/config/packages/symfony_command_ui.yaml
+++ b/pascualmg/symfony-command-ui/1.0/config/packages/symfony_command_ui.yaml
@@ -1,0 +1,3 @@
+symfony_command_ui:
+    route_prefix: /symfony-console
+    collapsed_by_default: true

--- a/pascualmg/symfony-command-ui/1.0/config/routes/symfony_command_ui.yaml
+++ b/pascualmg/symfony-command-ui/1.0/config/routes/symfony_command_ui.yaml
@@ -1,0 +1,3 @@
+symfony_command_ui:
+    resource: '@SymfonyCommandUIBundle/Resources/config/routes.yaml'
+    prefix: /symfony-console

--- a/pascualmg/symfony-command-ui/1.0/manifest.json
+++ b/pascualmg/symfony-command-ui/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Pascualmg\\SymfonyCommandUI\\SymfonyCommandUIBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/pascualmg/symfony-command-ui/1.0/post-install.txt
+++ b/pascualmg/symfony-command-ui/1.0/post-install.txt
@@ -1,0 +1,3 @@
+  * Configure which commands to expose in <fg=yellow>config/packages/symfony_command_ui.yaml</>
+  * Open <fg=yellow>/symfony-console/</> in your browser to see the dashboard
+  * Docs: <fg=yellow>https://github.com/pascualmg/symfony-command-ui</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [https://packagist.org/packages/pascualmg/symfony-command-ui](https://packagist.org/packages/pascualmg/symfony-command-ui)

Recipe for `pascualmg/symfony-command-ui` — a bundle that exposes Symfony console commands as a Web UI dashboard + AI-ready NDJSON API.

## Recipe contents

- **Bundle registration**: `SymfonyCommandUIBundle` for all envs
- **`config/packages/symfony_command_ui.yaml`**: route prefix + collapsed_by_default
- **`config/routes/symfony_command_ui.yaml`**: route import with prefix
- **`post-install.txt`**: hints for configuration

## Package

- GitHub: https://github.com/pascualmg/symfony-command-ui
- Current version: v1.0.5
- Requires: Symfony 4.4+ / 5.x / 6.x / 7.x, PHP 7.4+