### PR TITLE
[sentry/sentry-symfony] fix sentry.yaml extra spaces

### DIFF
--- a/sentry/sentry-symfony/5.0/config/packages/sentry.yaml
+++ b/sentry/sentry-symfony/5.0/config/packages/sentry.yaml
@@ -17,7 +17,7 @@ when@prod:
 #    monolog:
 #        handlers:
 #            # Use this only if you don't want to use structured logging and instead receive
-#            # certain log levels as errors.  
+#            # certain log levels as errors.
 #            sentry:
 #                type: service
 #                id: Sentry\Monolog\Handler


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sentry/sentry-symfony

Remove 2 extra spaces that would be automatically removed in any editor and messes up diffs when comparing the recipes-contrib version and imported version

<!--
Please, carefully read the Contributing section in the README
before submitting a pull request.
-->
