### PR TITLE
[pentiminax/ux-datatables] - Add recipe

### DIFF
--- a/pentiminax/ux-datatables/0.43/config/routes/data_tables.yaml
+++ b/pentiminax/ux-datatables/0.43/config/routes/data_tables.yaml
@@ -1,0 +1,2 @@
+datatables:
+    resource: '@DataTablesBundle/config/routes.php'

--- a/pentiminax/ux-datatables/0.43/manifest.json
+++ b/pentiminax/ux-datatables/0.43/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Pentiminax\\UX\\DataTables\\DataTablesBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/pentiminax/ux-datatables

Adds a Symfony Flex recipe for `pentiminax/ux-datatables`.
