### PR TITLE
Add recipe for rodmarzavala/infile-php-symfony

### DIFF
--- a/rodmarzavala/infile-php-symfony/1.0/config/packages/infile_php.yaml
+++ b/rodmarzavala/infile-php-symfony/1.0/config/packages/infile_php.yaml
@@ -1,0 +1,6 @@
+infile_php:
+    credentials:
+        sign_user: '%env(FEL_SIGN_USER)%'
+        sign_key: '%env(FEL_SIGN_KEY)%'
+        api_user: '%env(FEL_API_USER)%'
+        api_key: '%env(FEL_API_KEY)%'

--- a/rodmarzavala/infile-php-symfony/1.0/manifest.json
+++ b/rodmarzavala/infile-php-symfony/1.0/manifest.json
@@ -11,5 +11,10 @@
         "FEL_SIGN_KEY": "",
         "FEL_API_USER": "",
         "FEL_API_KEY": ""
+    },
+    "conflict": {
+        "php": "<8.2",
+        "symfony/framework-bundle": "<6.4",
+        "symfony/symfony": ">=8.0"
     }
 }

--- a/rodmarzavala/infile-php-symfony/1.0/manifest.json
+++ b/rodmarzavala/infile-php-symfony/1.0/manifest.json
@@ -11,6 +11,5 @@
         "FEL_SIGN_KEY": "",
         "FEL_API_USER": "",
         "FEL_API_KEY": ""
-    },
-    "aliases": ["infile-php", "fel"]
+    }
 }

--- a/rodmarzavala/infile-php-symfony/1.0/manifest.json
+++ b/rodmarzavala/infile-php-symfony/1.0/manifest.json
@@ -11,10 +11,5 @@
         "FEL_SIGN_KEY": "",
         "FEL_API_USER": "",
         "FEL_API_KEY": ""
-    },
-    "conflict": {
-        "php": "<8.2",
-        "symfony/framework-bundle": "<6.4",
-        "symfony/symfony": ">=8.0"
     }
 }

--- a/rodmarzavala/infile-php-symfony/1.0/manifest.json
+++ b/rodmarzavala/infile-php-symfony/1.0/manifest.json
@@ -1,0 +1,16 @@
+{
+    "bundles": {
+        "InfilePhp\\Symfony\\InfilePhpBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#1": "Infile FEL API credentials",
+        "FEL_SIGN_USER": "",
+        "FEL_SIGN_KEY": "",
+        "FEL_API_USER": "",
+        "FEL_API_KEY": ""
+    },
+    "aliases": ["infile-php", "fel"]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/rodmarzavala/infile-php-symfony

This PR adds the Symfony Flex recipe for the `rodmarzavala/infile-php-symfony` package, a native Symfony adapter for the open-source infile-php SDK (Guatemala electronic invoicing).