### PR TITLE
Add recipe for lubomirfiala/sulu-preview-nav

### DIFF
--- a/lubomirfiala/sulu-preview-nav/0.1/manifest.json
+++ b/lubomirfiala/sulu-preview-nav/0.1/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Lubomirfiala\\SuluPreviewNav\\SuluPreviewNavBundle": ["all"]
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/lubomirfiala/sulu-preview-nav

Adds a Flex recipe for lubomirfiala/sulu-preview-nav, a Symfony bundle that enables click-to-edit block navigation in the Sulu 3 CMS admin preview. The recipe auto-registers the bundle in config/bundles.php.