### PR TITLE
Update rekalogika/temporary-url-bundle to use php-based route config

### DIFF
--- a/rekalogika/temporary-url-bundle/1.8/config/routes/rekalogika_temporary_url.yaml
+++ b/rekalogika/temporary-url-bundle/1.8/config/routes/rekalogika_temporary_url.yaml
@@ -1,0 +1,3 @@
+rekalogika_temporary_url:
+    resource: '@RekalogikaTemporaryUrlBundle/config/routes.php'
+    prefix: /_temporary

--- a/rekalogika/temporary-url-bundle/1.8/manifest.json
+++ b/rekalogika/temporary-url-bundle/1.8/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Rekalogika\\TemporaryUrl\\RekalogikaTemporaryUrlBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [rekalogika/temporary-url-bundle](https://packagist.org/packages/rekalogika/temporary-url-bundle)

This updates the recipe to use routes.php instead of the deprecated routes.xml
