### PR TITLE
fix(php_codesniffer): Ignore `config/reference.php`

### DIFF
--- a/squizlabs/php_codesniffer/3.6/phpcs.xml.dist
+++ b/squizlabs/php_codesniffer/3.6/phpcs.xml.dist
@@ -16,4 +16,6 @@
     <file>src/</file>
     <file>tests/</file>
 
+    <exclude-pattern>config/reference.php</exclude-pattern>
+
 </ruleset>

--- a/squizlabs/php_codesniffer/3.6/phpcs.xml.dist
+++ b/squizlabs/php_codesniffer/3.6/phpcs.xml.dist
@@ -16,6 +16,6 @@
     <file>src/</file>
     <file>tests/</file>
 
-    <exclude-pattern>config/reference.php</exclude-pattern>
+    <exclude-pattern>config/reference\.php$</exclude-pattern>
 
 </ruleset>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Since Symfony v7.4/v8.0, a `config/reference.php` file is auto-generated. CodeSniffer produces many false positives for this file, which can safely be ignored.


