### PR TITLE
Add recipe for vinceamstoutz/symfony-security-auditor 1.0

### DIFF
--- a/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
+++ b/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
@@ -7,4 +7,12 @@ when@dev: &symfony_security_auditor
         # attacker_model: 'claude-opus-4-8' # Dedicated model for the Attacker role. Falls back to `model` when unset.
         # reviewer_model: 'claude-haiku-4-5-20251001' # Lighter model for the Reviewer role. Falls back to `model` when unset.
 
+        # Proactive rate limiting — adjust the values to your provider plan.
+        # Any single dimension enables it: https://github.com/vinceamstoutz/symfony-security-auditor/blob/main/docs/configuration.md#auditrate_limit--proactive-throttling
+        # audit:
+        #     rate_limit: # Example: Anthropic Tier 1 quotas for Claude Opus 4.x (https://platform.claude.com/docs/en/api/rate-limits)
+        #         requests_per_minute: 50
+        #         input_tokens_per_minute: 500000 # Cached input tokens don't count toward Anthropic's limit.
+        #         output_tokens_per_minute: 80000
+
 when@test: *symfony_security_auditor

--- a/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
+++ b/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
@@ -4,7 +4,7 @@
 when@dev: &symfony_security_auditor
     symfony_security_auditor:
         model: 'claude-opus-4-8' # Model for both the Attacker and Reviewer roles. Bundle default: claude-opus-4-7.
-        # attacker_model: 'claude-opus-4-7' # Dedicated model for the Attacker role. Falls back to `model` when unset.
+        # attacker_model: 'claude-opus-4-8' # Dedicated model for the Attacker role. Falls back to `model` when unset.
         # reviewer_model: 'claude-haiku-4-5-20251001' # Lighter model for the Reviewer role. Falls back to `model` when unset.
 
 when@test: *symfony_security_auditor

--- a/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
+++ b/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
@@ -1,0 +1,10 @@
+# Full configuration reference (models, scan, audit loop, rate limits, caching):
+# https://github.com/vinceamstoutz/symfony-security-auditor/blob/main/docs/configuration.md
+#
+when@dev: &symfony_security_auditor
+    symfony_security_auditor:
+        model: 'claude-opus-4-8' # Model for both the Attacker and Reviewer roles. Bundle default: claude-opus-4-7.
+        # attacker_model: 'claude-opus-4-7' # Dedicated model for the Attacker role. Falls back to `model` when unset.
+        # reviewer_model: 'claude-haiku-4-5-20251001' # Lighter model for the Reviewer role. Falls back to `model` when unset.
+
+when@test: *symfony_security_auditor

--- a/vinceamstoutz/symfony-security-auditor/1.0/manifest.json
+++ b/vinceamstoutz/symfony-security-auditor/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "VinceAmstoutz\\SymfonySecurityAuditor\\SymfonySecurityAuditorBundle": ["dev", "test"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/vinceamstoutz/symfony-security-auditor


:information_source: The bundle is compatible for  `PHP 8.3+` and `Symfony 7.4+` so it's why some CI checks still red.