### PR TITLE
Add recipe for traceway/opentelemetry-symfony

### DIFF
--- a/traceway/opentelemetry-symfony/2.1/config/packages/open_telemetry.yaml
+++ b/traceway/opentelemetry-symfony/2.1/config/packages/open_telemetry.yaml
@@ -1,0 +1,15 @@
+open_telemetry:
+    traces:
+        excluded_paths: ['/_profiler', '/_wdt', '/health']
+
+when@test:
+    open_telemetry:
+        traces:
+            enabled: false
+        metrics:
+            enabled: false
+        logs:
+            correlation:
+                enabled: false
+            export:
+                enabled: false

--- a/traceway/opentelemetry-symfony/2.1/manifest.json
+++ b/traceway/opentelemetry-symfony/2.1/manifest.json
@@ -16,6 +16,5 @@
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
         "#5": "Protocol: http/json | http/protobuf | grpc — use http/json unless ext-protobuf is installed",
         "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"
-    },
-    "aliases": ["otel", "opentelemetry"]
+    }
 }

--- a/traceway/opentelemetry-symfony/2.1/manifest.json
+++ b/traceway/opentelemetry-symfony/2.1/manifest.json
@@ -1,0 +1,21 @@
+{
+    "bundles": {
+        "Traceway\\OpenTelemetryBundle\\OpenTelemetryBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#1": "OpenTelemetry SDK auto-initialization",
+        "OTEL_PHP_AUTOLOAD_ENABLED": "true",
+        "#2": "Service identity (shown in your backend)",
+        "OTEL_SERVICE_NAME": "%project_name%",
+        "#3": "Traces exporter: otlp | zipkin | console | none",
+        "OTEL_TRACES_EXPORTER": "otlp",
+        "#4": "Collector or backend endpoint",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+        "#5": "Protocol: http/json | http/protobuf | grpc — use http/json unless ext-protobuf is installed",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"
+    },
+    "aliases": ["otel", "opentelemetry"]
+}

--- a/traceway/opentelemetry-symfony/2.1/post-install.txt
+++ b/traceway/opentelemetry-symfony/2.1/post-install.txt
@@ -1,0 +1,12 @@
+
+  * <fg=blue>OpenTelemetry Symfony Bundle</> is wired and ready to trace your app.
+
+  * Verify your wiring:
+
+      <comment>$ bin/console traceway:doctor</comment>
+
+  * Override <comment>OTEL_*</> environment variables in <comment>.env.local</> to point at your backend.
+
+  * Documentation:
+
+      <comment>https://github.com/tracewayapp/opentelemetry-symfony-bundle</>


### PR DESCRIPTION

| Q                    | A
| ------------- | ---
| License          | MIT

Adds a Flex recipe for [traceway/opentelemetry-symfony](https://github.com/tracewayapp/opentelemetry-symfony-bundle) - a pure-PHP OpenTelemetry instrumentation bundle for Symfony 6.4 LTS / 7.x / 8.x. No C extension required.

  The bundle ships automatic tracing for HTTP, Console, HttpClient, Messenger, Mailer, Scheduler, Doctrine DBAL, Cache, and Twig; Monolog log-trace correlation; opt-in OTel log export; and opt-in metrics. It is stable since v1.0 and currently at v2.1.0.

  ## What the recipe does

  - Registers `Traceway\OpenTelemetryBundle\OpenTelemetryBundle` in `config/bundles.php` for all environments.
  - Adds an `OTEL_*` env-var block to `.env` with the minimum needed to point at a local OTel Collector at `http://localhost:4318` over `http/json`.
  - Creates a minimal `config/packages/open_telemetry.yaml` that excludes profiler / WDT / health-check paths from tracing in dev and disables all signals in the `test` environment.
  - Post-install message points users to `bin/console traceway:doctor` to verify wiring.

  ## Aliases

  Proposed: `otel`, `opentelemetry`. Happy to drop either if they conflict with existing claims.

  ## Stability

  The bundle is stable since v1.0 (Aug 2024), follows SemVer, has PHPStan level 10 with no baseline, and CI runs across PHP 8.1–8.5 × Symfony 6.4 / 7.x / 8.x × DBAL 3+4. Public service tags
  (`traceway.doctor.check`) and config schema (`open_telemetry.*`) are documented and stable.