### PR TITLE
Add 4.39 recipe for sonata-project/admin-bundle with PHP routing

### DIFF
--- a/sonata-project/admin-bundle/4.39/config/packages/sonata_admin.yaml
+++ b/sonata-project/admin-bundle/4.39/config/packages/sonata_admin.yaml
@@ -1,0 +1,10 @@
+sonata_admin:
+    title: 'Sonata Admin'
+    dashboard:
+        blocks:
+            - { type: sonata.admin.block.admin_list, position: left }
+
+sonata_block:
+    blocks:
+        sonata.admin.block.admin_list:
+            contexts: [admin]

--- a/sonata-project/admin-bundle/4.39/config/routes/sonata_admin.yaml
+++ b/sonata-project/admin-bundle/4.39/config/routes/sonata_admin.yaml
@@ -1,0 +1,9 @@
+admin_area:
+    resource: "@SonataAdminBundle/Resources/config/routing/sonata_admin.php"
+    type: php
+    prefix: /admin
+
+_sonata_admin:
+    resource: .
+    type: sonata_admin
+    prefix: /admin

--- a/sonata-project/admin-bundle/4.39/manifest.json
+++ b/sonata-project/admin-bundle/4.39/manifest.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "Sonata\\AdminBundle\\SonataAdminBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "src/": "%SRC_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sonata-project/admin-bundle

## Problem

`sonata_admin.xml` routing is broken in Symfony 8.0, which removed `XmlFileLoader` support for routing (it was deprecated in 7.4). This causes:

> Cannot load resource "@SonataAdminBundle/Resources/config/routing/sonata_admin.xml"

See: sonata-project/SonataAdminBundle#8374

## Why a new recipe version instead of editing 4.0

The PHP routing file `sonata_admin.php` was [introduced in SonataAdminBundle 4.39.0](https://github.com/sonata-project/SonataAdminBundle/blob/4.39.0/src/Resources/config/routing/sonata_admin.php). Modifying the `4.0` recipe to reference it would break installations running older versions (as noted in the review on PR #1989).

## Solution

Add a new `4.39` recipe version that references `sonata_admin.php` with `type: php`, leaving the `4.0` recipe untouched for older installs.

This supersedes PR #1989 which addressed the same issue but modified the `4.0` recipe directly.