### PR TITLE
Add recipe for shedeza/sybase-orm-bundle 1.0

### DIFF
--- a/shedeza/sybase-orm-bundle/1.0/config/packages/sybase_orm.yaml
+++ b/shedeza/sybase-orm-bundle/1.0/config/packages/sybase_orm.yaml
@@ -1,0 +1,9 @@
+sybase_orm:
+    connection:
+        url: '%env(DATABASE_URL)%'
+    entity_directories:
+        - '%kernel.project_dir%/src/Entity'
+    proxy_directory: '%kernel.cache_dir%/sybase_orm/proxies'
+    migrations_directory: '%kernel.project_dir%/sybase_ase/migrations'
+    cache:
+        enabled: false

--- a/shedeza/sybase-orm-bundle/1.0/manifest.json
+++ b/shedeza/sybase-orm-bundle/1.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "SybaseORM\\Bundle\\SybaseORMBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "DATABASE_URL": "sybase://sa:!ChangeMe!@127.0.0.1:5000/app?charset=UTF-8"
+    }
+}


### PR DESCRIPTION
## New Recipe

**Package:** shedeza/sybase-orm-bundle
**Version:** 1.0
**Packagist:** https://packagist.org/packages/shedeza/sybase-orm-bundle

### What it does

- Registers SybaseORM Bundle SybaseORMBundle in all environments
- Copies config/packages/sybase_orm.yaml with default connection config using DATABASE_URL
- Adds DATABASE_URL template to .env

### Package description

Symfony Bundle providing DI integration, console commands, web profiler support, and Flex recipe for shedeza/sybase-orm (a pure PHP ORM for Sybase ASE databases).


## Licencia

Esta contribución está licenciada bajo la licencia MIT.

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/shedeza/sybase-orm-bundle