### PR TITLE
Add letkode form schema bundle recipe

### DIFF
--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -1,0 +1,24 @@
+letkode_form_schema:
+    default_locale: es
+    available_locales:
+        - es
+    entity_namespace: App\Entity
+    table_prefix: ''
+    table_names:
+        form: ~
+        form_section: ~
+        form_group: ~
+        form_field: ~
+        form_option_general: ~
+        form_option_general_value: ~
+    cache:
+        enabled: false
+        pool: cache.app
+        ttl: 3600
+        key_prefix: fsb
+        auto_invalidate: true
+    disabled_field_types: []
+    disabled_options_sources: []
+    disabled_form_renders: []
+    disabled_section_renders: []
+    disabled_group_renders: []

--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -5,12 +5,12 @@ letkode_form_schema:
     entity_namespace: App\Entity
     table_prefix: ''
     table_names:
-        form: ~
-        form_section: ~
-        form_group: ~
-        form_field: ~
-        form_option_general: ~
-        form_option_general_value: ~
+        form: null
+        form_section: null
+        form_group: null
+        form_field: null
+        form_option_general: null
+        form_option_general_value: null
     cache:
         enabled: false
         pool: cache.app

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+  "bundles": {
+    "Letkode\\FormSchemaBundle\\LetkodeFormSchemaBundle": ["all"]
+  },
+  "copy-from-recipe": {
+    "config/": "%CONFIG_DIR%/"
+  }
+}

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -1,8 +1,8 @@
 {
-  "bundles": {
-    "Letkode\\FormSchemaBundle\\LetkodeFormSchemaBundle": ["all"]
-  },
-  "copy-from-recipe": {
-    "config/": "%CONFIG_DIR%/"
-  }
+    "bundles": {
+        "Letkode\\FormSchemaBundle\\LetkodeFormSchemaBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/letkode/form-schema-bundle

<!--
  Adds the official Symfony Flex recipe for `letkode/form-schema-bundle`.                                                        
                                                                                                                                 
  **What this recipe does:**                                                                                                     
  - Registers `LetkodeFormSchemaBundle` for all environments                                                                     
  - Copies `config/packages/letkode_form_schema.yaml` with sane defaults:                                                        
    - Default locale: `es`                                                                                                       
    - Entity namespace: `App\Entity`                                                                                             
    - Cache disabled by default (configurable via `cache.app`)                                                                   
    - All field types, option sources, and renders enabled by default
    
 **Note:** This bundle requires PHP ^8.4. Tests against environments                                                          
   with PHP < 8.4 (e.g. sf7-php82) are expected to fail.
-->
