### PR TITLE
Update letkode/form-schema-bundle recipe V1

### DIFF
--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -4,7 +4,7 @@ letkode_form_schema:
         - es
     entity_namespace: App\Entity
     table_prefix: ''
-    seeds_path: '%kernel.project_dir%/config/seeds/form-schema'
+    seeds_path: '%kernel.project_dir%/config/seeds/form_schema'
     table_names:
         form: null
         form_section: null

--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -10,8 +10,8 @@ letkode_form_schema:
         form_section: null
         form_group: null
         form_field: null
-        form_option_general: null
-        form_option_general_value: null
+        form_option: null
+        form_option_value: null
     cache:
         enabled: false
         pool: cache.app

--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -1,9 +1,6 @@
 letkode_form_schema:
-    default_locale: es
-    available_locales:
-        - es
-        - en
-        - pt
+    default_locale: '%env(LKA_DEFAULT_LOCALE)%'
+    available_locales: '%env(csv:LKA_AVAILABLE_LOCALES)%'
     entity_namespace: App\Entity
     table_prefix: ''
     seeds_path: '%kernel.project_dir%/config/seeds/form_schema'
@@ -15,7 +12,7 @@ letkode_form_schema:
         form_option: null
         form_option_value: null
     cache:
-        enabled: false
+        enabled: '%env(bool:LKA_FORM_SCHEMA_CACHE)%'
         pool: cache.app
         ttl: 3600
         key_prefix: fsb

--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -1,6 +1,9 @@
 letkode_form_schema:
     default_locale: '%env(LKA_DEFAULT_LOCALE)%'
-    available_locales: '%env(csv:LKA_AVAILABLE_LOCALES)%'
+    available_locales:
+        - es
+        - en
+        - pt
     entity_namespace: App\Entity
     table_prefix: ''
     seeds_path: '%kernel.project_dir%/config/seeds/form_schema'

--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -2,6 +2,8 @@ letkode_form_schema:
     default_locale: es
     available_locales:
         - es
+        - en
+        - pt
     entity_namespace: App\Entity
     table_prefix: ''
     seeds_path: '%kernel.project_dir%/config/seeds/form_schema'

--- a/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
+++ b/letkode/form-schema-bundle/1.0/config/packages/letkode_form_schema.yaml
@@ -4,6 +4,7 @@ letkode_form_schema:
         - es
     entity_namespace: App\Entity
     table_prefix: ''
+    seeds_path: '%kernel.project_dir%/config/seeds/form-schema'
     table_names:
         form: null
         form_section: null

--- a/letkode/form-schema-bundle/1.0/config/seeds/form_schema/forms/.gitignore
+++ b/letkode/form-schema-bundle/1.0/config/seeds/form_schema/forms/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/letkode/form-schema-bundle/1.0/config/seeds/form_schema/options/.gitignore
+++ b/letkode/form-schema-bundle/1.0/config/seeds/form_schema/options/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -3,8 +3,6 @@
         "Letkode\\FormSchemaBundle\\LetkodeFormSchemaBundle": ["all"]
     },
     "copy-from-recipe": {
-        "config/packages/": "%CONFIG_DIR%/packages/",
-        "config/seeds/": "%CONFIG_DIR%/seeds/"
-    },
-    "gitignore": []
+        "config/packages/": "%CONFIG_DIR%/packages/"
+    }
 }

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -3,6 +3,8 @@
         "Letkode\\FormSchemaBundle\\LetkodeFormSchemaBundle": ["all"]
     },
     "copy-from-recipe": {
-        "config/": "%CONFIG_DIR%/"
-    }
+        "config/packages/": "%CONFIG_DIR%/packages/",
+        "config/seeds/": "%CONFIG_DIR%/seeds/"
+    },
+    "gitignore": []
 }

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -4,5 +4,10 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "LKA_DEFAULT_LOCALE": "es",
+        "LKA_AVAILABLE_LOCALES": "es,en,pt",
+        "LKA_FORM_SCHEMA_CACHE": "false"
     }
 }

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -7,7 +7,6 @@
     },
     "env": {
         "LKA_DEFAULT_LOCALE": "es",
-        "LKA_AVAILABLE_LOCALES": "es,en,pt",
         "LKA_FORM_SCHEMA_CACHE": "false"
     }
 }

--- a/letkode/form-schema-bundle/1.0/manifest.json
+++ b/letkode/form-schema-bundle/1.0/manifest.json
@@ -3,6 +3,6 @@
         "Letkode\\FormSchemaBundle\\LetkodeFormSchemaBundle": ["all"]
     },
     "copy-from-recipe": {
-        "config/packages/": "%CONFIG_DIR%/packages/"
+        "config/": "%CONFIG_DIR%/"
     }
 }


### PR DESCRIPTION
| Q             | A                                                                                                                  
  | ------------- | ---                                                                                                                
  | License       | MIT                                                                                                                
  | Packagist     | https://packagist.org/packages/letkode/form-schema-bundle                                                          

<!--
**What this update does:**
 - Adds `seeds_path` parameter to `letkode_form_schema.yaml`
 - Copies `config/seeds/form-schema/forms/` and `config/seeds/form-schema/general-options/` directories via recipe
    
**Note:** This bundle requires PHP ^8.4. Tests against environments with PHP < 8.4 (e.g. sf7-php82) are expected to fail.    
-->  