### PR TITLE
Add recipe for treblle/treblle-symfony

### DIFF
--- a/treblle/treblle-symfony/4.0/config/packages/treblle.yaml
+++ b/treblle/treblle-symfony/4.0/config/packages/treblle.yaml
@@ -1,0 +1,3 @@
+treblle:
+    sdk_token: '%env(TREBLLE_SDK_TOKEN)%'
+    api_key: '%env(TREBLLE_API_KEY)%'

--- a/treblle/treblle-symfony/4.0/manifest.json
+++ b/treblle/treblle-symfony/4.0/manifest.json
@@ -1,0 +1,12 @@
+{
+    "bundles": {
+        "Treblle\\Symfony\\TreblleBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "TREBLLE_SDK_TOKEN": "",
+        "TREBLLE_API_KEY": ""
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/treblle/treblle-symfony

## What

Adds a Symfony Flex recipe for [`treblle/treblle-symfony`](https://packagist.org/packages/treblle/treblle-symfony) — an API monitoring and documentation SDK for Symfony.

## What the recipe does

On `composer require treblle/treblle-symfony`:

- Registers `TreblleBundle` in `config/bundles.php` for all environments
- Creates `config/packages/treblle.yaml` with the minimal required configuration pointing at env vars
- Injects `TREBLLE_SDK_TOKEN` and `TREBLLE_API_KEY` stubs into `.env`

## Package

- Packagist: https://packagist.org/packages/treblle/treblle-symfony
- Repository: https://github.com/treblle/treblle-symfony
- License: MIT
- PHP: ^8.2
- Symfony: ^6.4 | ^7.0 | ^8.0