### PR TITLE
Add piairre/skuse recipe

### DIFF
--- a/piairre/skuse/0.1/config/packages/piairre_skuse.yaml
+++ b/piairre/skuse/0.1/config/packages/piairre_skuse.yaml
@@ -1,0 +1,3 @@
+piairre_skuse:
+    open_api_url: '/api/docs.json'
+    # theme: 'system' # light, dark, system

--- a/piairre/skuse/0.1/config/routes/piairre_skuse.yaml
+++ b/piairre/skuse/0.1/config/routes/piairre_skuse.yaml
@@ -1,0 +1,3 @@
+piairre_skuse:
+    resource: '@PiairreSkuseBundle/config/routes.yaml'
+    prefix: /skuse # URL where the documentation is served

--- a/piairre/skuse/0.1/manifest.json
+++ b/piairre/skuse/0.1/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Piairre\\Skuse\\PiairreSkuseBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/piairre/skuse

## Summary

Adds the Symfony Flex recipe for [`piairre/skuse`](https://github.com/Piairre/Skuse), a modern OpenAPI documentation viewer for Symfony powered by [skuse-ui](https://github.com/Piairre/skuse-ui).

## What the recipe does

- Creates `config/packages/piairre_skuse.yaml` with the `open_api_url` parameter to configure the OpenAPI spec path
- Creates `config/routes/piairre_skuse.yaml` to register the documentation route (served at `/skuse` by default)