### PR TITLE
feat(symfony-security-auditor): add JSON schema

### DIFF
--- a/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
+++ b/vinceamstoutz/symfony-security-auditor/1.0/config/packages/symfony_security_auditor.yaml
@@ -1,3 +1,5 @@
+# $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
+
 # Full configuration reference (models, scan, audit loop, rate limits, caching):
 # https://github.com/vinceamstoutz/symfony-security-auditor/blob/main/docs/configuration.md
 #


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/vinceamstoutz/symfony-security-auditor

Adds a JSON Schema modeline to the `symfony_security_auditor` recipe config so
editors provide completion, validation and inline docs for the bundle config.

```yaml
# $schema: https://raw.githubusercontent.com/vinceamstoutz/symfony-security-auditor/main/resources/schema.json
```

- Works in **PhpStorm/IntelliJ** (native `# $schema:` support) and the **Red Hat
  yaml-language-server** (VS Code, Neovim), which also understands the `# $schema:` form.
- The URL floats on the package's `main` branch **on purpose**: Symfony Flex has no
  package-version placeholder for recipe file contents, so a pinned tag would need
  editing on every release. A floating ref keeps the recipe maintenance-free and always
  resolves to the current schema.
- One-line, comment-only change — no behavioural impact on the generated config.

Schema lives at `resources/schema.json` in the bundle repo.