### PR TITLE
Add galactic-shrine/gsid recipe

### DIFF
--- a/galactic-shrine/gsid/1.0/config/packages/gsid.yaml
+++ b/galactic-shrine/gsid/1.0/config/packages/gsid.yaml
@@ -1,0 +1,6 @@
+gsid:
+    default_case: Lower
+    default_text_format: N
+    default_json_format: D
+    default_database_format: N
+    lock: true

--- a/galactic-shrine/gsid/1.0/manifest.json
+++ b/galactic-shrine/gsid/1.0/manifest.json
@@ -6,8 +6,5 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    },
-    "aliases": [
-        "gsid"
-    ]
+    }
 }

--- a/galactic-shrine/gsid/1.0/manifest.json
+++ b/galactic-shrine/gsid/1.0/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "GalacticShrine\\GsId\\Symfony\\GsIdBundle": [
+            "all"
+        ]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": [
+        "gsid"
+    ]
+}

--- a/galactic-shrine/gsid/1.0/post-install.txt
+++ b/galactic-shrine/gsid/1.0/post-install.txt
@@ -1,0 +1,5 @@
+<bg=blue;fg=white> GsId </>
+
+  * The GsId bundle was enabled in config/bundles.php.
+  * A default configuration file was created at config/packages/gsid.yaml.
+  * For GsId 1.x, declare the Doctrine DBAL type manually if your installed 1.x version does not register it automatically.

--- a/galactic-shrine/gsid/2.0/config/packages/gsid.yaml
+++ b/galactic-shrine/gsid/2.0/config/packages/gsid.yaml
@@ -1,0 +1,6 @@
+gsid:
+    default_case: Lower
+    default_text_format: N
+    default_json_format: D
+    default_database_format: N
+    lock: true

--- a/galactic-shrine/gsid/2.0/manifest.json
+++ b/galactic-shrine/gsid/2.0/manifest.json
@@ -6,8 +6,5 @@
     },
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
-    },
-    "aliases": [
-        "gsid"
-    ]
+    }
 }

--- a/galactic-shrine/gsid/2.0/manifest.json
+++ b/galactic-shrine/gsid/2.0/manifest.json
@@ -1,0 +1,13 @@
+{
+    "bundles": {
+        "GalacticShrine\\GsId\\Symfony\\GsIdBundle": [
+            "all"
+        ]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": [
+        "gsid"
+    ]
+}

--- a/galactic-shrine/gsid/2.0/post-install.txt
+++ b/galactic-shrine/gsid/2.0/post-install.txt
@@ -1,0 +1,5 @@
+<bg=blue;fg=white> GsId </>
+
+  * The GsId bundle was enabled in config/bundles.php.
+  * A default configuration file was created at config/packages/gsid.yaml.
+  * If DoctrineBundle is installed, the bundle registers the DBAL type "gsid" automatically.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/galactic-shrine/gsid

Adds Symfony Flex recipes for `galactic-shrine/gsid`.

Recipes included:

- `1.0` for GsId 1.x
- `2.0` for GsId 2.x

The recipes enable the Symfony bundle and create the default configuration file:

- `config/packages/gsid.yaml`

For GsId 2.x, Doctrine DBAL type registration is handled by the bundle when DoctrineBundle is installed, so the recipe does not modify `doctrine.yaml`.

Package license: `MPL-2.0`.