### PR TITLE
[alexivanou/russian-text-bundle] add recipe for v1.0

### DIFF
--- a/alexivanou/russian-text-bundle/1.0/config/packages/russian_text.yaml
+++ b/alexivanou/russian-text-bundle/1.0/config/packages/russian_text.yaml
@@ -1,0 +1,18 @@
+# RussianTextBundle configuration
+# See https://github.com/alexivanou/russian-text-bundle for documentation
+russian_text:
+    # All services are enabled by default.
+    # Set any to false to disable unused functionality.
+    enable_pluralizer: true
+    enable_number_speller: true
+    enable_money_speller: true
+    enable_name_inflector: true
+    enable_noun_decliner: true
+    enable_adjective_decliner: true
+    enable_geo_inflector: true
+    enable_time_speller: true
+    enable_twig_plural: true
+    enable_twig_numeral: true
+    enable_twig_name: true
+    enable_twig_declension: true
+    enable_twig_time: true

--- a/alexivanou/russian-text-bundle/1.0/manifest.json
+++ b/alexivanou/russian-text-bundle/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "AlexIvanou\\RussianTextBundle\\AlexIvanouRussianTextBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/alexivanou/russian-text-bundle/1.0/post-install.txt
+++ b/alexivanou/russian-text-bundle/1.0/post-install.txt
@@ -1,0 +1,6 @@
+RussianTextBundle installed!
+
+Available Twig filters: pluralize, cardinal, ordinal, spell_money, inflect_name, noun_case, noun_plural, adj_case, geo_case, time_ago, distance_of_time
+Available Twig functions: name_cases, detect_gender
+
+See README for usage examples.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/alexivanou/russian-text-bundle

Symfony bundle providing Russian text functions: pluralization, number spelling,
name inflection, noun/adjective declension, geographical name inflection,
money spelling, time ago, transliteration, phone formatting, identifier validation
(INN, SNILS, OGRN, SWIFT, IBAN, etc.), name parsing, date formatting, text helpers.
Built on wapmorgan/morphos.

All service flags are pure toggles defaulting to true — disabled services are
removed from the container at compile time.
