### PR TITLE
Add soviann/deploy-tasks-bundle recipe

### DIFF
--- a/soviann/deploy-tasks-bundle/0.1/config/packages/soviann_deploy_tasks.yaml
+++ b/soviann/deploy-tasks-bundle/0.1/config/packages/soviann_deploy_tasks.yaml
@@ -1,0 +1,7 @@
+soviann_deploy_tasks:
+    storage:
+        type: filesystem
+        filesystem:
+            path: '%kernel.project_dir%/var/deploy-tasks'
+
+    # Full reference: vendor/soviann/deploy-tasks-bundle/docs/

--- a/soviann/deploy-tasks-bundle/0.1/manifest.json
+++ b/soviann/deploy-tasks-bundle/0.1/manifest.json
@@ -1,0 +1,17 @@
+{
+    "bundles": {
+        "Soviann\\DeployTasksBundle\\SoviannDeployTasksBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/",
+        "deploy/": "deploy/"
+    },
+    "copy-from-package": {
+        "bin/deploy-tasks-host.sh.dist": "%BIN_DIR%/deploy-tasks-host.sh"
+    },
+    "gitignore": [
+        "/.deploy-tasks-host.log",
+        "/.deploy-tasks-host.lock",
+        "/deploy-tasks-host.local.sh"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/soviann/deploy-tasks-bundle

Adds the recipe for [soviann/deploy-tasks-bundle](https://packagist.org/packages/soviann/deploy-tasks-bundle) (v0.1.0, MIT) — one-time deploy tasks for Symfony: attribute-declared task classes run exactly once per environment, tracked in filesystem/DBAL/custom storage, with transaction modes, task groups, run locking, and a host-scope runner.

The recipe:
- registers the bundle for all environments;
- publishes a minimal `config/packages/soviann_deploy_tasks.yaml` (filesystem storage under `var/deploy-tasks`);
- copies the host-scope runner from the package to `bin/deploy-tasks-host.sh` and creates `deploy/host-tasks/` for its task scripts;
- ignores the runner's log/lock/local-override files.

The same manifest has been serving from a dedicated endpoint and is verified end-to-end (fresh `symfony/skeleton` + `composer require` → bundle registered, config published, runner installed, `bin/console deploytasks:status` works).