### PR TITLE
Add fluffydiscord/roadrunner-symfony-bundle 7.0 and 7.1 recipes

### DIFF
--- a/fluffydiscord/roadrunner-symfony-bundle/7.0/config/packages/fluffy_discord_road_runner.yaml
+++ b/fluffydiscord/roadrunner-symfony-bundle/7.0/config/packages/fluffy_discord_road_runner.yaml
@@ -1,0 +1,77 @@
+fluffy_discord_road_runner:
+    # Optional
+    # Specify relative path from "kernel.project_dir" to your RoadRunner config file
+    # if you want to run cache:warmup without having your RoadRunner running in background,
+    # e.g. when building Docker images. Default is ".rr.yaml"
+    rr_config_path: ".rr.yaml"
+
+    # https://docs.roadrunner.dev/http/http
+    http:
+        # Optional
+        # -----------
+        # This decides when to boot the Symfony kernel.
+        #
+        # false (default) - before first request (worker takes some time to be ready, but app has consistent response times)
+        # true - once first request arrives (worker is ready immediately, but inconsistent response times due to kernel boot time spikes)
+        #
+        # If you use large amount of workers, you might want to set this to true or else the RR boot up might
+        # take a lot of time or just boot up using only a few "emergency" workers
+        # and then use dynamic worker scaling as described here https://docs.roadrunner.dev/php-worker/scaling
+        lazy_boot: false
+
+    # Zero-config worker pre-warming: workers serve their first request at near-hot speed.
+    # Replaces the "early_router_initialization" option removed in v7.
+    # https://github.com/FluffyDiscord/roadrunner-symfony-bundle#worker-warmup
+    warmup:
+        # Optional
+        # -----------
+        # Master switch for the whole system (boot-time warmers + learned manifest).
+        enabled: true
+
+        # Optional
+        # -----------
+        # Learn from real traffic: each worker records what responses load, and every
+        # later worker replays it before RoadRunner marks it ready.
+        learn: true
+
+        # Optional
+        # -----------
+        # Stop recording after this many responses per worker process.
+        learn_requests: 30
+
+        # Optional
+        # -----------
+        # Where the learned manifest is stored.
+        # Default: "<kernel.cache_dir>/roadrunner/warmup.manifest.json"
+        manifest_path: null
+
+    # https://docs.roadrunner.dev/plugins/centrifuge
+    centrifugo:
+        # Optional
+        # -----------
+        # See http section
+        lazy_boot: false
+
+    # https://docs.roadrunner.dev/key-value/overview-kv
+    kv:
+        # Optional
+        # -----------
+        # If true (default), bundle will automatically register all "kv" adapters in your .rr.yaml.
+        # Registered services have alias "cache.adapter.rr_kv.NAME"
+        auto_register: true
+
+        # Optional
+        # -----------
+        # Which serializer should be used.
+        # By default, "IgbinarySerializer" will be used if "igbinary" php extension
+        # is installed (recommended), otherwise "DefaultSerializer".
+        # You are free to create your own serializer, it needs to implement
+        # Spiral\RoadRunner\KeyValue\Serializer\SerializerInterface
+        serializer: null
+
+        # Optional
+        # -----------
+        # Specify relative path from "kernel.project_dir" to a keypair file
+        # for end-to-end encryption. "sodium" php extension is required.
+        # https://docs.roadrunner.dev/key-value/overview-kv#end-to-end-value-encryption
+        keypair_path: bin/keypair.key

--- a/fluffydiscord/roadrunner-symfony-bundle/7.0/manifest.json
+++ b/fluffydiscord/roadrunner-symfony-bundle/7.0/manifest.json
@@ -1,0 +1,14 @@
+{
+    "bundles": {
+        "FluffyDiscord\\RoadRunnerBundle\\FluffyDiscordRoadRunnerBundle": ["all"]
+    },
+    "copy-from-package": {
+        "install/.rr.yaml": ".rr.yaml"
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "RR_RPC": "tcp://127.0.0.1:6001"
+    }
+}

--- a/fluffydiscord/roadrunner-symfony-bundle/7.1/config/packages/fluffy_discord_road_runner.yaml
+++ b/fluffydiscord/roadrunner-symfony-bundle/7.1/config/packages/fluffy_discord_road_runner.yaml
@@ -1,0 +1,96 @@
+fluffy_discord_road_runner:
+    # Optional
+    # Specify relative path from "kernel.project_dir" to your RoadRunner config file
+    # if you want to run cache:warmup without having your RoadRunner running in background,
+    # e.g. when building Docker images. Default is ".rr.yaml"
+    rr_config_path: ".rr.yaml"
+
+    # https://docs.roadrunner.dev/http/http
+    http:
+        # Optional
+        # -----------
+        # This decides when to boot the Symfony kernel.
+        #
+        # false (default) - before first request (worker takes some time to be ready, but app has consistent response times)
+        # true - once first request arrives (worker is ready immediately, but inconsistent response times due to kernel boot time spikes)
+        #
+        # If you use large amount of workers, you might want to set this to true or else the RR boot up might
+        # take a lot of time or just boot up using only a few "emergency" workers
+        # and then use dynamic worker scaling as described here https://docs.roadrunner.dev/php-worker/scaling
+        lazy_boot: false
+
+        # Optional
+        # -----------
+        # How the RoadRunner request is converted into a Symfony request.
+        #
+        # native (fastest) - build the Symfony Request directly from the RoadRunner
+        # request, skipping the intermediate PSR-7 object. Roughly halves the
+        # per-request conversion cost.
+        # psr7 - the previous behavior: build a PSR-7 request first, then convert it
+        # via symfony/psr-http-message-bridge. Use this when you decorate the
+        # conversion with a custom HttpFoundationFactoryInterface service
+        # (that service is picked up automatically).
+        # auto (default) - psr7 when a custom HttpFoundationFactoryInterface service
+        # is registered, native otherwise.
+        #
+        # The small, deliberate behavior differences of "native" (uploaded-file
+        # class/pathname, verbatim header forwarding, raw query-string encoding)
+        # are listed in the bundle's UPGRADE.md.
+        request_factory: auto
+
+    # Zero-config worker pre-warming: workers serve their first request at near-hot speed.
+    # Replaces the "early_router_initialization" option removed in v7.
+    # https://github.com/FluffyDiscord/roadrunner-symfony-bundle#worker-warmup
+    warmup:
+        # Optional
+        # -----------
+        # Master switch for the whole system (boot-time warmers + learned manifest).
+        enabled: true
+
+        # Optional
+        # -----------
+        # Learn from real traffic: each worker records what responses load, and every
+        # later worker replays it before RoadRunner marks it ready.
+        learn: true
+
+        # Optional
+        # -----------
+        # Stop recording after this many responses per worker process.
+        learn_requests: 30
+
+        # Optional
+        # -----------
+        # Where the learned manifest is stored.
+        # Default: "<kernel.cache_dir>/roadrunner/warmup.manifest.json"
+        manifest_path: null
+
+    # https://docs.roadrunner.dev/plugins/centrifuge
+    centrifugo:
+        # Optional
+        # -----------
+        # See http section
+        lazy_boot: false
+
+    # https://docs.roadrunner.dev/key-value/overview-kv
+    kv:
+        # Optional
+        # -----------
+        # If true (default), bundle will automatically register all "kv" adapters in your .rr.yaml.
+        # Registered services have alias "cache.adapter.rr_kv.NAME"
+        auto_register: true
+
+        # Optional
+        # -----------
+        # Which serializer should be used.
+        # By default, "IgbinarySerializer" will be used if "igbinary" php extension
+        # is installed (recommended), otherwise "DefaultSerializer".
+        # You are free to create your own serializer, it needs to implement
+        # Spiral\RoadRunner\KeyValue\Serializer\SerializerInterface
+        serializer: null
+
+        # Optional
+        # -----------
+        # Specify relative path from "kernel.project_dir" to a keypair file
+        # for end-to-end encryption. "sodium" php extension is required.
+        # https://docs.roadrunner.dev/key-value/overview-kv#end-to-end-value-encryption
+        keypair_path: bin/keypair.key

--- a/fluffydiscord/roadrunner-symfony-bundle/7.1/manifest.json
+++ b/fluffydiscord/roadrunner-symfony-bundle/7.1/manifest.json
@@ -1,0 +1,14 @@
+{
+    "bundles": {
+        "FluffyDiscord\\RoadRunnerBundle\\FluffyDiscordRoadRunnerBundle": ["all"]
+    },
+    "copy-from-package": {
+        "install/.rr.yaml": ".rr.yaml"
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "RR_RPC": "tcp://127.0.0.1:6001"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/fluffydiscord/roadrunner-symfony-bundle

I'm the bundle author.

### 7.0 recipe

v7.0.0 removed the `http.early_router_initialization` option (the 2.3/3.0 recipe default config throws an `InvalidConfigurationException` on v7) and replaced it with a zero-config worker pre-warming system configured under a new top-level `warmup` node.

The 7.0 recipe drops the removed option (including its `when@dev` override) and documents the new `warmup` options with their defaults. Manifest is unchanged.

Bundle release: https://github.com/FluffyDiscord/roadrunner-symfony-bundle/releases/tag/v7.0.0

### 7.1 recipe

v7.1.0 adds an `http.request_factory` option (`auto`/`native`/`psr7`) that selects how the RoadRunner request is converted into a Symfony request; the new `native` default roughly halves the per-request conversion cost.

It is documented in a separate 7.1 recipe rather than being added to the 7.0 one, because the option does not exist in 7.0.x — writing it into a 7.0 install fails with `Unrecognized option "request_factory" under "fluffy_discord_road_runner.http"`, which is the same breakage this PR set out to fix. Both recipes were verified against their respective releases' configuration tree.

Bundle release: https://github.com/FluffyDiscord/roadrunner-symfony-bundle/releases/tag/v7.1.0
