### PR TITLE
Add recipe for cyllene-digital/sylius-axepta-plugin 1.0

### DIFF
--- a/cyllene-digital/sylius-axepta-plugin/1.0/config/routes/cyllene_digital_sylius_axepta.yaml
+++ b/cyllene-digital/sylius-axepta-plugin/1.0/config/routes/cyllene_digital_sylius_axepta.yaml
@@ -1,0 +1,2 @@
+cyllene_digital_sylius_axepta_shop:
+    resource: "@CylleneDigitalSyliusAxeptaPlugin/config/routes/shop.yaml"

--- a/cyllene-digital/sylius-axepta-plugin/1.0/manifest.json
+++ b/cyllene-digital/sylius-axepta-plugin/1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "CylleneDigital\\SyliusAxeptaPlugin\\CylleneDigitalSyliusAxeptaPlugin": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/cyllene-digital/sylius-axepta-plugin/1.0/post-install.txt
+++ b/cyllene-digital/sylius-axepta-plugin/1.0/post-install.txt
@@ -1,0 +1,20 @@
+  <fg=blue;options=bold>Sylius Axepta BNP Paribas Plugin</> is installed.
+
+  <options=bold>Two steps are left, and skipping either breaks payments without an error message:</>
+
+    1. Generate the payment encryption key, unless your project already has one:
+
+       <comment>bin/console sylius:payment:generate-key</>
+
+       Back that key up separately from the database: together they protect nothing, and losing it
+       makes the configuration of your payment methods unrecoverable.
+
+    2. Declare your trusted proxies in <comment>%CONFIG_DIR%/packages/framework.yaml</>, including
+       <comment>x-forwarded-host</>. Symfony does not trust that header by default, and it is the
+       only one carrying the public domain. Without it you hand the bank URLs it cannot reach, the
+       notification never arrives, and the order stays unpaid although the customer has paid.
+
+  Then create the payment method: <comment>Configuration > Payment methods > Create</>, gateway
+  "Axepta - BNP Paribas".
+
+  Documentation: https://github.com/CylleneDigital/SyliusAxeptaPlugin/blob/main/docs/installation.md


### PR DESCRIPTION
Registers the bundle and imports the shop routes, which expose the page the customer returns to from the bank-hosted payment page. Without that import the return URL cannot be built and the payment fails before it even leaves.

No config/packages: both configuration keys of the plugin have real defaults.
No add-lines either, the plugin ships no JavaScript. The two remaining steps cannot be automated and are recalled by post-install.txt: generating the Sylius payment encryption key, and declaring the trusted proxies, x-forwarded-host included, without which the URLs handed to the bank are unreachable.

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/cyllene-digital/sylius-axepta-plugin

Recipe for a Sylius 2 payment plugin integrating the Axepta BNP Paribas gateway.
