### PR TITLE
Add zestly/dev-login-bundle recipe for 0.1

### DIFF
--- a/zestly/dev-login-bundle/0.1/config/packages/dev/zestly_dev_login.yaml
+++ b/zestly/dev-login-bundle/0.1/config/packages/dev/zestly_dev_login.yaml
@@ -1,0 +1,16 @@
+zestly_dev_login:
+    # The identities offered by GET /_dev/login and `bin/console dev:login`.
+    #
+    # There is no sensible default for this — it depends entirely on your fixtures — which is
+    # why it is the one setting this recipe writes. Everything else the bundle exposes already
+    # has a working default and is documented in the README.
+    #
+    # This is a convenience menu, not a whitelist: any identifier your application's user
+    # provider accepts will work, and listing one here grants nothing on its own.
+    #
+    # To build the list from your fixtures, a repository, or per-subdomain in a multi-tenant
+    # app, implement Zestly\DevLoginBundle\Identity\IdentityProviderInterface and alias it —
+    # it receives the current Request.
+    identities: []
+        # - { identifier: 'admin@example.com', label: 'Admin', roles: ['ROLE_ADMIN'] }
+        # - { identifier: 'user@example.com',  label: 'Regular user' }

--- a/zestly/dev-login-bundle/0.1/config/routes/dev/zestly_dev_login.yaml
+++ b/zestly/dev-login-bundle/0.1/config/routes/dev/zestly_dev_login.yaml
@@ -1,0 +1,5 @@
+# Dev login endpoints. Loaded only because this file lives in config/routes/dev/ — that is
+# one of the bundle's safety gates, so a production router never learns these paths exist.
+# If you move this file out of a dev-scoped directory, you remove that gate.
+zestly_dev_login:
+    resource: '@ZestlyDevLoginBundle/config/routes.php'

--- a/zestly/dev-login-bundle/0.1/manifest.json
+++ b/zestly/dev-login-bundle/0.1/manifest.json
@@ -1,0 +1,26 @@
+{
+    "bundles": {
+        "Zestly\\DevLoginBundle\\ZestlyDevLoginBundle": ["dev"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "post-install-output": [
+        "  * Dev login is ready. Start your server and open:",
+        "",
+        "      <fg=yellow>/_dev/login</>              list the identities you can become",
+        "      <fg=yellow>/_dev/login/{identifier}</> log in as one of them, no password",
+        "",
+        "  * List them from the console instead:",
+        "",
+        "      <fg=yellow>php bin/console dev:login</>",
+        "",
+        "  * Declare who shows up in that list in <comment>config/packages/dev/zestly_dev_login.yaml</>.",
+        "",
+        "  * This grants password-free login to any account your user provider accepts.",
+        "    It registers no services outside the dev environment, and its routes live in",
+        "    <comment>config/routes/dev/</> so they do not exist in a production router.",
+        "",
+        "  * Docs: <comment>https://github.com/ZestlyDigital/dev-login-bundle</>"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Adds a recipe for [`zestly/dev-login-bundle`](https://packagist.org/packages/zestly/dev-login-bundle) — password-free login to your own application in the `dev` environment, so browser-driven testing (and coding agents doing it) don't stop to ask a human to type a password.

- Repository: https://github.com/ZestlyDigital/dev-login-bundle
- Requires PHP 8.2+, Symfony ^7.0 || ^8.0

### Why a recipe is needed

The bundle can't self-register its routes, and they must land in `config/routes/dev/` — that environment-scoped directory is one of its safety gates, ensuring the URLs don't exist in a production router at all. Without the recipe every user has to write that import by hand.

The recipe registers the bundle for `dev` only, and writes two files:

- `config/routes/dev/zestly_dev_login.yaml` — the routes import.
- `config/packages/dev/zestly_dev_login.yaml` — `identities`, the list of accounts offered by the discovery endpoint.

Per the Best Practices in the README, the package config contains only the one setting that has no sensible default and must be filled in by the application. The bundle's other options all have working defaults and are left to its documentation rather than shipped here.

### Checks

Validated locally against `symfony-tools/recipes-checker` before opening: `lint:manifests --contrib` and `lint:yaml` both exit 0, no aliases, all files listed under `copy-from-recipe`, 4-space indentation, trailing newlines, underscore notation, no `: ~` nulls, no `parameters:`.

I also installed the package into a fresh `symfony/skeleton:^8` with `extra.symfony.allow-contrib true`, applied this recipe, and confirmed the container compiles, both routes register and a login works end to end. That exercise found a bug in the bundle — `Security::login()` throws on the skeleton's authenticator-less `main` firewall — which is fixed in v0.1.1, released before opening this PR.