### PR TITLE
Add gijsrommers/smstools-notifier 0.2 recipe

### DIFF
--- a/gijsrommers/smstools-notifier/0.2/config/packages/smstools_notifier.yaml
+++ b/gijsrommers/smstools-notifier/0.2/config/packages/smstools_notifier.yaml
@@ -1,0 +1,4 @@
+framework:
+    notifier:
+        texter_transports:
+            smstools: '%env(SMS_TOOLS_DSN)%'

--- a/gijsrommers/smstools-notifier/0.2/manifest.json
+++ b/gijsrommers/smstools-notifier/0.2/manifest.json
@@ -7,5 +7,9 @@
     },
     "env": {
         "SMS_TOOLS_DSN": "smstools://CLIENT_ID:CLIENT_SECRET@default?from=MyApp"
+    },
+    "conflict": {
+        "php": "<8.2",
+        "symfony/framework-bundle": "<7.4"
     }
 }

--- a/gijsrommers/smstools-notifier/0.2/manifest.json
+++ b/gijsrommers/smstools-notifier/0.2/manifest.json
@@ -9,7 +9,7 @@
         "SMS_TOOLS_DSN": "smstools://CLIENT_ID:CLIENT_SECRET@default?from=MyApp"
     },
     "conflict": {
-        "php": "<8.2",
-        "symfony/framework-bundle": "<7.4"
+        "php": "<8.1",
+        "symfony/framework-bundle": "<6.4"
     }
 }

--- a/gijsrommers/smstools-notifier/0.2/manifest.json
+++ b/gijsrommers/smstools-notifier/0.2/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "GijsRommers\\SmstoolsNotifier\\SmstoolsNotifierBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "SMS_TOOLS_DSN": "smstools://CLIENT_ID:CLIENT_SECRET@default?from=MyApp"
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [gijsrommers/smstools-notifier](https://packagist.org/packages/gijsrommers/smstools-notifier)

Registers the package bundle, configures the SMSTools texter transport, and adds the `SMS_TOOLS_DSN` environment variable.

Source: https://github.com/GijsRommers/smstools-notifier
