### PR TITLE
[cache/cache-bundle] Add recipe for 2.0

### DIFF
--- a/cache/cache-bundle/2.0/manifest.json
+++ b/cache/cache-bundle/2.0/manifest.json
@@ -1,0 +1,5 @@
+{
+    "bundles": {
+        "Cache\\CacheBundle\\CacheBundle": ["all"]
+    }
+}

--- a/cache/cache-bundle/2.0/post-install.txt
+++ b/cache/cache-bundle/2.0/post-install.txt
@@ -1,0 +1,2 @@
+  * Configure the CacheBundle integrations that your app uses:
+    <href=https://github.com/php-cache/cache-bundle#configuration>https://github.com/php-cache/cache-bundle#configuration</>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/cache/cache-bundle

This adds the Flex recipe for CacheBundle 2.x. Version 2 registers the bundle without installing the obsolete 1.x configuration; applications opt into the integrations they use.