### PR TITLE
Disable fluffydiscord/roadrunner-symfony-bundle warmup in dev

### DIFF
--- a/fluffydiscord/roadrunner-symfony-bundle/7.1/config/packages/fluffy_discord_road_runner.yaml
+++ b/fluffydiscord/roadrunner-symfony-bundle/7.1/config/packages/fluffy_discord_road_runner.yaml
@@ -94,3 +94,12 @@ fluffy_discord_road_runner:
         # for end-to-end encryption. "sodium" php extension is required.
         # https://docs.roadrunner.dev/key-value/overview-kv#end-to-end-value-encryption
         keypair_path: bin/keypair.key
+
+when@dev:
+    fluffy_discord_road_runner:
+        # The shipped .rr.yaml runs the pool with "debug: true" (a fresh PHP process per request).
+        # Since v7.1.2 the bundle detects that and skips warmup by itself; this keeps it explicit.
+        # Warming a throwaway process only adds boot latency, and replaying compiled Twig templates
+        # early-binds their classes, so Twig would keep serving a template you just edited.
+        warmup:
+            enabled: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/fluffydiscord/roadrunner-symfony-bundle

The recipe's `.rr.yaml` runs the worker pool with `http.pool.debug: true` (one PHP process per request). The bundle's worker warmup is pointless there (nothing survives to a second request, ~1s extra boot per request) and harmful: replaying compiled Twig templates through `opcache_compile_file()` early-binds their classes, so Twig skips its `auto_reload` check and keeps serving stale templates after an edit.

Bundle v7.1.2 detects this at runtime and skips warmup by itself; this adds the explicit `when@dev` override to the 7.1 recipe so the behaviour is visible in the generated config.