### PR TITLE
Remove redundant SMSTools recipe conflicts

### DIFF
--- a/gijsrommers/smstools-notifier/0.2/manifest.json
+++ b/gijsrommers/smstools-notifier/0.2/manifest.json
@@ -7,9 +7,5 @@
     },
     "env": {
         "SMS_TOOLS_DSN": "smstools://CLIENT_ID:CLIENT_SECRET@default?from=MyApp"
-    },
-    "conflict": {
-        "php": "<8.1",
-        "symfony/framework-bundle": "<6.4"
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/gijsrommers/smstools-notifier

Fixes the review comment left by @diimpp on #2028: https://github.com/symfony/recipes-contrib/pull/2028#discussion_r3813035480

The package already declares its supported PHP and Symfony versions through Composer, so these constraints do not belong in the recipe's conflict block.