### PR TITLE
Add lgarret/health-check-bundle 1.0 recipe

### DIFF
--- a/lgarret/health-check-bundle/1.0/config/packages/health_check.yaml
+++ b/lgarret/health-check-bundle/1.0/config/packages/health_check.yaml
@@ -1,0 +1,11 @@
+health_check:
+    path: '/health'
+    secret: '%env(HEALTH_CHECK_SECRET)%'
+    header: 'Authorization'
+    timeout: 5
+    cache:
+        enabled: true
+        ttl: 300
+    checks:
+        doctrine: true
+        asset_mapper: true

--- a/lgarret/health-check-bundle/1.0/config/routes/health_check.yaml
+++ b/lgarret/health-check-bundle/1.0/config/routes/health_check.yaml
@@ -1,0 +1,3 @@
+health_check:
+    resource: .
+    type: health_check

--- a/lgarret/health-check-bundle/1.0/manifest.json
+++ b/lgarret/health-check-bundle/1.0/manifest.json
@@ -1,0 +1,26 @@
+{
+    "bundles": {
+        "Lgarret\\HealthCheckBundle\\HealthCheckBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "HEALTH_CHECK_SECRET": "!ChangeMe!"
+    },
+    "post-install-output": [
+        "  * The health check endpoint is exposed at <fg=green>/health</>.",
+        "",
+        "  * Replace the <comment>HEALTH_CHECK_SECRET</> placeholder in <comment>.env</> with a real value.",
+        "    Callers sending it in the <comment>Authorization</> header get the detailed check results;",
+        "    everyone else only sees the global status.",
+        "",
+        "  * If your firewall covers every path, grant it anonymous access in <comment>config/packages/security.yaml</>:",
+        "        <comment>access_control:</>",
+        "            <comment>- { path: ^/health$, roles: PUBLIC_ACCESS }</>",
+        "",
+        "  * Enable, disable and tune the checks in <comment>config/packages/health_check.yaml</>.",
+        "",
+        "  * Docs: <comment>https://github.com/LouisGarret/health-check-bundle</>"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [lgarret/health-check-bundle](https://packagist.org/packages/lgarret/health-check-bundle)

[lgarret/health-check-bundle](https://github.com/LouisGarret/health-check-bundle) exposes a `/health` endpoint reporting the status of the application and its dependencies. Doctrine connections and AssetMapper are auto-detected; custom checks implement `HealthCheckInterface`. It supports Symfony 6.4, 7.x and 8.x.

The recipe registers the bundle, imports the route — which the bundle serves through its own routing loader, so the path stays configurable — writes `config/packages/health_check.yaml` with the defaults made explicit, and provisions `HEALTH_CHECK_SECRET`.

`HEALTH_CHECK_SECRET` gets the `!ChangeMe!` placeholder rather than an empty value on purpose: the controller compares it with `hash_equals()`, so an empty secret would match an empty `Authorization` header and hand the detailed check results to any caller.

Source: https://github.com/LouisGarret/health-check-bundle
