### PR TITLE
Add tito10047/iconcaptcha-bundle 0.1

### DIFF
--- a/tito10047/iconcaptcha-bundle/0.1/config/packages/icon_captcha.yaml
+++ b/tito10047/iconcaptcha-bundle/0.1/config/packages/icon_captcha.yaml
@@ -1,0 +1,9 @@
+icon_captcha:
+    theme: light
+
+# A test cannot solve a challenge, so the protected form has to stay submittable.
+# "enable: false" switches both ends at once: nothing is rendered and the
+# constraint always passes.
+when@test:
+    icon_captcha:
+        enable: false

--- a/tito10047/iconcaptcha-bundle/0.1/config/routes/icon_captcha.yaml
+++ b/tito10047/iconcaptcha-bundle/0.1/config/routes/icon_captcha.yaml
@@ -1,0 +1,3 @@
+icon_captcha:
+    resource: '@IconcaptchaBundle/config/routes.php'
+    type: php

--- a/tito10047/iconcaptcha-bundle/0.1/manifest.json
+++ b/tito10047/iconcaptcha-bundle/0.1/manifest.json
@@ -1,0 +1,36 @@
+{
+    "bundles": {
+        "Tito10047\\IconcaptchaBundle\\IconcaptchaBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "add-lines": [
+        {
+            "file": "assets/app.js",
+            "content": [
+                "import '@fabianwennink/iconcaptcha/css/iconcaptcha.min.css';"
+            ],
+            "position": "top",
+            "requires": "symfony/asset-mapper",
+            "warn_if_missing": true
+        }
+    ],
+    "post-install-output": [
+        "  <bg=blue;fg=white>              </>",
+        "  <bg=blue;fg=white> What's next? </>",
+        "  <bg=blue;fg=white>              </>",
+        "",
+        "  * The captcha needs a session: make sure <comment>framework.session</> is enabled.",
+        "",
+        "  * <fg=blue>Add</> the widget to a form:",
+        "    <comment>$builder->add('captcha', Tito10047\\IconcaptchaBundle\\Type\\IconCaptchaType::class);</>",
+        "",
+        "  * <fg=blue>Serve</> the client assets. With AssetMapper they were just declared in",
+        "    <comment>importmap.php</>; without it, run <comment>php bin/console iconcaptcha:install-assets</>",
+        "    once and after every update of <comment>fabianwennink/iconcaptcha</>.",
+        "",
+        "  * <fg=blue>Read</> the documentation at <comment>https://github.com/tito10047/IconCaptchaBundle</>",
+        ""
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist   | https://packagist.org/packages/tito10047/iconcaptcha-bundle

Recipe for [tito10047/iconcaptcha-bundle](https://github.com/tito10047/IconCaptchaBundle) — a Symfony bundle wrapping [fabianwennink/iconcaptcha](https://github.com/fabianwennink/IconCaptcha-PHP), a self-hosted icon-based captcha.

The recipe:

* registers the bundle;
* installs `config/packages/icon_captcha.yaml` with a light theme, plus a `when@test` block that disables the captcha — a functional test cannot solve a challenge, and `enable: false` switches off both the rendering and the constraint so the protected form stays submittable;
* installs `config/routes/icon_captcha.yaml`, importing the bundle's routes for the widget's AJAX endpoint;
* imports the library's stylesheet in `assets/app.js` when AssetMapper is in use. The JS deliberately is *not* imported: it is not an ES module, so the Stimulus controller loads it as a classic script through the importmap instead.

The package is on Packagist with a stable `0.1.0` release.

---

**About the one red leg in "Run updated recipes":** the `skeleton:^6` job on PHP 8.1 cannot
install the package — the bundle requires `php >=8.2`, while that job pins PHP 8.1. Symfony
6.4 itself is supported: the `skeleton:^6` job on PHP 8.4 is green, as are the `^7` and `^8`
jobs. Every other leg of the matrix passes.