### PR TITLE
Update sulu/mcp-bundle recipe for symfony/mcp-bundle 0.13

### DIFF
--- a/sulu/mcp-bundle/1.0/config/packages/sulu_mcp.yaml
+++ b/sulu/mcp-bundle/1.0/config/packages/sulu_mcp.yaml
@@ -8,16 +8,19 @@ sulu_mcp:
 # ownership of a file that is not ours.
 
 mcp:
-    http:
-        # DNS rebinding protection. Left unset it accepts localhost only, so a server
-        # reachable under its own domain answers every request with "403 Forbidden:
-        # Invalid Host header." after the OAuth handshake already succeeded, and without
-        # writing anything to the log. Hosts carry no port.
-        allowed_hosts:
-            - '%env(key:host:url:SULU_MCP_SERVER_URL)%'
-            - localhost
-            - 127.0.0.1
-            - '[::1]'
+    servers:
+        # The server SuluMcpBundle prepends; its remaining options are set there.
+        sulu:
+            http:
+                # DNS rebinding protection. Left unset it accepts localhost only, so a server
+                # reachable under its own domain answers every request with "403 Forbidden:
+                # Invalid Host header." after the OAuth handshake already succeeded, and without
+                # writing anything to the log. Hosts carry no port.
+                allowed_hosts:
+                    - '%env(key:host:url:SULU_MCP_SERVER_URL)%'
+                    - localhost
+                    - 127.0.0.1
+                    - '[::1]'
 
 league_oauth2_server:
     scopes:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/sulu/mcp-bundle

Follow-up to #2034.

`symfony/mcp-bundle` 0.13 replaced the single implicit MCP server with named servers configured under `mcp.servers`, each with its own identity, transports and HTTP settings. `sulu/mcp-bundle` prepends one called `sulu`, so the `allowed_hosts` this recipe writes moves from `mcp.http` to `mcp.servers.sulu.http`.

Nothing else changes: `manifest.json` and `config/routes/sulu_mcp.yaml` are untouched, and the option itself keeps its meaning and its value.

The `1.0` directory is updated in place rather than branched into a new version: `sulu/mcp-bundle` is still at `1.0.0-RC1`, and the `allowed_hosts` block this recipe already carries needs the same not-yet-released bundle version (its `symfony/mcp-bundle` constraint moves to `^0.13` in sulu/SuluMcpBundle#34).


---

**On the red "Run updated recipes" job.** It installs the recipe against the released `sulu/mcp-bundle` `1.0.0-RC1`, whose constraint is still `symfony/mcp-bundle ^0.6`, so the skeleton resolves a pre-0.13 version that has no `servers` key and `cache:clear` reports `Unrecognized option "servers" under "mcp"`. The same job was already red on #2034 (there on a Sulu service missing from the bare skeleton, plus the Symfony 6.4/8.1 legs the package does not support).

Please hold this until the next `sulu/mcp-bundle` release, which raises the constraint to `^0.13`; merged before that, Flex would write the new key into installations running the older bundle.
