### PR TITLE
Add gplanchat/durable-bundle recipe

### DIFF
--- a/gplanchat/durable-bundle/0.1/config/packages/durable.yaml
+++ b/gplanchat/durable-bundle/0.1/config/packages/durable.yaml
@@ -1,0 +1,23 @@
+durable:
+    # in_memory keeps the journal in the PHP process: right for tests, lost on restart.
+    # Use dbal to keep it in your database, or set temporal.dsn to reach a Temporal cluster.
+    event_store:
+        type: in_memory
+    workflow_metadata:
+        type: in_memory
+    activity_transport:
+        type: messenger
+        transport_name: durable_activities
+
+framework:
+    messenger:
+        transports:
+            durable_workflows: '%env(MESSENGER_DURABLE_WORKFLOW_DSN)%'
+            durable_activities: '%env(MESSENGER_DURABLE_ACTIVITY_DSN)%'
+
+        routing:
+            Gplanchat\Durable\Transport\ResumeWorkflowMessage: durable_workflows
+            Gplanchat\Durable\Transport\ActivityMessage: durable_activities
+            Gplanchat\Durable\Transport\FireWorkflowTimersMessage: sync
+            Gplanchat\Durable\Transport\DeliverWorkflowSignalMessage: sync
+            Gplanchat\Durable\Transport\DeliverWorkflowUpdateMessage: sync

--- a/gplanchat/durable-bundle/0.1/manifest.json
+++ b/gplanchat/durable-bundle/0.1/manifest.json
@@ -1,0 +1,27 @@
+{
+    "bundles": {
+        "Gplanchat\\Durable\\Bundle\\DurableBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#1": "Where workflow resumes and activity runs are queued.",
+        "#2": "sync:// handles them in the same process, which matches the in_memory",
+        "#3": "backend the config starts from. Point them at a real transport",
+        "#4": "(doctrine://, amqp://, redis://) when you move the journal off memory.",
+        "MESSENGER_DURABLE_WORKFLOW_DSN": "sync://",
+        "MESSENGER_DURABLE_ACTIVITY_DSN": "sync://"
+    },
+    "post-install-output": [
+        "  * Durable starts on the <comment>in_memory</comment> backend: workflows run, and are lost with the process.",
+        "    Set <comment>event_store.type</comment> and <comment>workflow_metadata.type</comment> to <comment>dbal</comment> in",
+        "    <comment>config/packages/durable.yaml</comment> to keep the journal in your database, and point the two",
+        "    <comment>MESSENGER_DURABLE_*_DSN</comment> variables at a real transport.",
+        "",
+        "  * Then run the workers:",
+        "    <comment>php bin/console messenger:consume durable_workflows durable_activities</comment>",
+        "",
+        "  * Documentation: <comment>https://durable.rocks/docs/getting-started/</comment>"
+    ]
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/gplanchat/durable-bundle

[`gplanchat/durable-bundle`](https://packagist.org/packages/gplanchat/durable-bundle) brings durable execution to Symfony: long-running business logic written as a plain PHP class, journalled and replayed so it survives deploys, restarts and crashes. Workflow resumes and activity runs travel over Symfony Messenger, so the bundle needs transports and routing before it does anything at all — which is what this recipe sets up.

Docs: https://durable.rocks

### What the recipe writes

`config/packages/durable.yaml`, with the backend the bundle already defaults to (`in_memory` — no infrastructure, correct for a fresh install and for tests), plus the Messenger transports and the routing of the five message classes the bundle dispatches.

Two env vars, both defaulting to `sync://`. That is deliberate: `in-memory://` collects messages without handling them, so a fresh install would silently do nothing, and `doctrine://` would assume a transport dependency the project may not have. `sync://` handles them in-process, which matches the `in_memory` backend the config starts from. The post-install output says what to change when moving off memory.

### On the `framework.messenger` block

The best practices say a recipe should not modify another bundle's configuration, with one exception — appending to a config collection, the given example being a new DoctrineBundle connection. The transports and routing entries here are exactly that: additions to `framework.messenger.transports` and `framework.messenger.routing`, under names prefixed `durable_`.

Without them the bundle installs and does nothing, since every workflow resume and activity dispatch goes through Messenger. If you would rather this stayed out of the recipe, say so and I will drop it and move the block to the post-install output instead.

### `bundles`

The package is `"type": "symfony-bundle"`, so Flex registers it on its own when no recipe exists. The `bundles` key is here so that adding this recipe does not take that away.