### PR TITLE
Add recipe for mosl/opensign-bridge-bundle

### DIFF
--- a/mosl/opensign-bridge-bundle/0.6/config/packages/opensign_bridge.yaml
+++ b/mosl/opensign-bridge-bundle/0.6/config/packages/opensign_bridge.yaml
@@ -1,0 +1,7 @@
+open_sign_bridge:
+    opensign:
+        app_id: '%env(OPENSIGN_APP_ID)%'
+        master_key: '%env(OPENSIGN_MASTER_KEY)%'
+        api_url: '%env(OPENSIGN_API_URL)%'
+        user_id: '%env(OPENSIGN_USER_ID)%'
+        session_token: '%env(OPENSIGN_SESSION_TOKEN)%'

--- a/mosl/opensign-bridge-bundle/0.6/manifest.json
+++ b/mosl/opensign-bridge-bundle/0.6/manifest.json
@@ -1,0 +1,8 @@
+{
+    "bundles": {
+        "Mosl\\OpenSignBridgeBundle\\OpenSignBridgeBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    }
+}

--- a/mosl/opensign-bridge-bundle/0.6/post-install.txt
+++ b/mosl/opensign-bridge-bundle/0.6/post-install.txt
@@ -1,0 +1,7 @@
+  * <fg=blue>Configure your OpenSign connection in</> <comment>config/packages/opensign_bridge.yaml</>
+    and set the required env vars: OPENSIGN_APP_ID, OPENSIGN_MASTER_KEY, OPENSIGN_API_URL,
+    OPENSIGN_USER_ID, OPENSIGN_SESSION_TOKEN. See:
+    <comment>https://github.com/imdela/OpenSignBridgeBundle#-installation-in-a-host-app</>
+
+  * <fg=blue>Deploy a self-hosted OpenSign server (Docker) yourself</> — this bundle only
+    provides the PHP client/integration layer, not the OpenSign server itself.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | [mosl/opensign-bridge-bundle](https://packagist.org/packages/mosl/opensign-bridge-bundle)

[mosl/opensign-bridge-bundle](https://github.com/imdela/OpenSignBridgeBundle) bridges a self-hosted OpenSign server (Parse Server based e-signature) into a Symfony app: uploading documents, creating guest signers, creating signature requests, and polling for completion (OpenSign's self-hosted server has no outbound webhook).

The recipe registers the bundle and writes `config/packages/opensign_bridge.yaml` with the required connection settings pulled from env vars — no defaults, since app_id/master_key/session_token are credentials for an OpenSign instance the consuming app deploys and configures itself; the bundle only provides the PHP client/integration layer.

Source: https://github.com/imdela/OpenSignBridgeBundle

---

**Note on "Run updated recipes":** this check fails on the `sf6-php81`/`sf7-php82` legs — the bundle requires `php >=8.4` (a real requirement of `symfony/framework-bundle:^8.0`, not an arbitrary choice), so it cannot install on Symfony 6/7 skeletons. This matches the case the workflow itself documents as expected ("You can ignore this error if your package does not support Symfony 6"). The `sf8-php84` leg installs cleanly.
