### PR TITLE
Fix odiseoteam/sylius-rbac-plugin admin route prefix

### DIFF
--- a/odiseoteam/sylius-rbac-plugin/3.0/config/routes/odiseo_sylius_rbac_plugin.yaml
+++ b/odiseoteam/sylius-rbac-plugin/3.0/config/routes/odiseo_sylius_rbac_plugin.yaml
@@ -1,3 +1,3 @@
 odiseo_sylius_rbac_admin:
     resource: "@OdiseoSyliusRbacPlugin/config/routes/admin.yaml"
-    prefix: /admin
+    prefix: '/%sylius_admin.path_name%'

--- a/odiseoteam/sylius-rbac-plugin/3.0/post-install.txt
+++ b/odiseoteam/sylius-rbac-plugin/3.0/post-install.txt
@@ -2,17 +2,9 @@
   <bg=blue;fg=white> What's next? </>
   <bg=blue;fg=white>              </>
 
-  * <fg=blue>Make</> your AdminUser administration-role aware: add
-    <comment>AdministrationRoleAwareInterface</> and <comment>AdministrationRoleAwareTrait</>
-    to your <comment>AdminUser</> entity. This plugin cannot do it for you -- that class is
-    yours, and may already extend or implement other things.
-
-  * <fg=blue>Update</> your database schema:
-    <comment>bin/console doctrine:migrations:migrate</>
+  * <fg=blue>Read</> the full installation guide at
+    <comment>https://github.com/odiseoteam/SyliusRbacPlugin/blob/master/doc/installation.md</>
 
   * <fg=blue>Grant</> yourself access. A fresh install denies every administrator
     everything, including the screen that assigns roles:
     <comment>bin/console odiseo:rbac:grant <username-or-email> super_admin --create</>
-
-  * <fg=blue>Read</> the full installation guide, including the AdminUser snippet, at
-    <comment>https://github.com/odiseoteam/SyliusRbacPlugin/blob/master/doc/installation.md</>


### PR DESCRIPTION
The recipe hardcoded prefix: /admin, so on any install that customizes SYLIUS_ADMIN_ROUTING_PATH_NAME the plugin's own admin routes land outside sylius.security.admin_regex and are unreachable through the admin firewall. Use the same parameterized prefix Sylius' own admin routes use.

Also trims the post-install note: the AdminUser snippet and the migration command are already covered by the linked installation guide.

| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/odiseoteam/sylius-rbac-plugin