### PR TITLE
Add tailsfadmin/tailsfadmin-bundle

### DIFF
--- a/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin.yaml
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin.yaml
@@ -1,0 +1,11 @@
+# Configuration par défaut du thème tailsfadmin (recette Flex, US-029).
+# Éditez le menu selon votre application ; les `label` sont des clés de traduction
+# (i18n) ou des libellés bruts. Voir le README du bundle.
+tailsfadmin:
+    default_locale: fr
+    locales: ['fr', 'en', 'ar', 'es', 'de']
+    rtl_locales: ['ar']
+    menu:
+        - group: menu.groups.menu
+          items:
+              - { label: menu.dashboard, path: /, icon: dashboard }

--- a/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin.yaml
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin.yaml
@@ -1,6 +1,6 @@
-# Configuration par défaut du thème tailsfadmin (recette Flex, US-029).
-# Éditez le menu selon votre application ; les `label` sont des clés de traduction
-# (i18n) ou des libellés bruts. Voir le README du bundle.
+# Default configuration for the tailsfadmin admin theme (Flex recipe).
+# Adjust the menu to your application; `label` values are translation keys (i18n)
+# or raw labels. See the bundle README.
 tailsfadmin:
     default_locale: fr
     locales: ['fr', 'en', 'ar', 'es', 'de']

--- a/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin.yaml
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin.yaml
@@ -6,6 +6,7 @@ tailsfadmin:
     locales: ['fr', 'en', 'ar', 'es', 'de']
     rtl_locales: ['ar']
     menu:
-        - group: menu.groups.menu
-          items:
-              - { label: menu.dashboard, path: /, icon: dashboard }
+        -
+            group: menu.groups.menu
+            items:
+                - { label: menu.dashboard, path: /, icon: dashboard }

--- a/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin_assets.yaml
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin_assets.yaml
@@ -1,0 +1,11 @@
+# Path AssetMapper des contrôleurs Stimulus du bundle (recette Flex, US-029).
+#
+# Le prepend() du bundle ne survit pas au merge Flex : on déclare ici, côté hôte,
+# le path des contrôleurs (et du shim vendor-src FullCalendar). Fichier SÉPARÉ
+# exprès — Symfony fusionne framework.asset_mapper.paths de tous les fichiers de
+# config/packages/, donc ceci s'ajoute à votre asset_mapper.yaml sans l'écraser.
+framework:
+    asset_mapper:
+        paths:
+            'vendor/tailsfadmin/tailsfadmin-bundle/assets/controllers': 'bundles/tailsfadmin'
+            'vendor/tailsfadmin/tailsfadmin-bundle/assets/vendor-src': 'bundles/tailsfadmin-vendor'

--- a/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin_assets.yaml
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/config/packages/tailsfadmin_assets.yaml
@@ -1,9 +1,10 @@
-# Path AssetMapper des contrôleurs Stimulus du bundle (recette Flex, US-029).
+# AssetMapper path for the bundle's Stimulus controllers (Flex recipe).
 #
-# Le prepend() du bundle ne survit pas au merge Flex : on déclare ici, côté hôte,
-# le path des contrôleurs (et du shim vendor-src FullCalendar). Fichier SÉPARÉ
-# exprès — Symfony fusionne framework.asset_mapper.paths de tous les fichiers de
-# config/packages/, donc ceci s'ajoute à votre asset_mapper.yaml sans l'écraser.
+# The bundle's prepend() does not survive the Flex config merge, so the controllers
+# path (and the FullCalendar vendor-src shim) is declared here, on the host side.
+# Kept in a SEPARATE file on purpose: Symfony merges framework.asset_mapper.paths
+# from every config/packages/ file, so this adds to your asset_mapper.yaml
+# without overwriting it.
 framework:
     asset_mapper:
         paths:

--- a/tailsfadmin/tailsfadmin-bundle/1.0/manifest.json
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/manifest.json
@@ -5,7 +5,6 @@
     "copy-from-recipe": {
         "config/": "%CONFIG_DIR%/"
     },
-    "aliases": ["tailsfadmin"],
     "post-install-output": [
         "<bg=blue;fg=white> tailsfadmin </> admin theme installed.",
         "",

--- a/tailsfadmin/tailsfadmin-bundle/1.0/manifest.json
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/manifest.json
@@ -1,0 +1,26 @@
+{
+    "bundles": {
+        "Tailsfadmin\\TailsfadminBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "aliases": ["tailsfadmin"],
+    "post-install-output": [
+        "<bg=blue;fg=white> tailsfadmin </> thème admin installé.",
+        "",
+        "  Le bundle ne dépend d'aucun CDN — deux étapes pour les assets :",
+        "",
+        "  1. Vendorer les libs JS des composants (ApexCharts, flatpickr, Dropzone, …) :",
+        "     <comment>php bin/console tailsfadmin:assets:install</comment>",
+        "",
+        "  2. Importer le thème dans votre entrée Tailwind (assets/styles/app.css) :",
+        "     <comment>@import \"tailwindcss\";</comment>",
+        "     <comment>@import \"../../vendor/tailsfadmin/tailsfadmin-bundle/assets/styles/theme.css\";</comment>",
+        "",
+        "  Puis compilez : <comment>php bin/console tailwind:build && php bin/console asset-map:compile</comment>",
+        "",
+        "  Le path AssetMapper des contrôleurs est déjà posé (config/packages/tailsfadmin_assets.yaml).",
+        "  Documentation : <comment>https://github.com/thibmonier/tailsfadmin#readme</comment>"
+    ]
+}

--- a/tailsfadmin/tailsfadmin-bundle/1.0/manifest.json
+++ b/tailsfadmin/tailsfadmin-bundle/1.0/manifest.json
@@ -7,20 +7,20 @@
     },
     "aliases": ["tailsfadmin"],
     "post-install-output": [
-        "<bg=blue;fg=white> tailsfadmin </> thème admin installé.",
+        "<bg=blue;fg=white> tailsfadmin </> admin theme installed.",
         "",
-        "  Le bundle ne dépend d'aucun CDN — deux étapes pour les assets :",
+        "  The bundle ships no CDN dependency — two steps for the assets:",
         "",
-        "  1. Vendorer les libs JS des composants (ApexCharts, flatpickr, Dropzone, …) :",
+        "  1. Vendor the components' third-party JS libs (ApexCharts, flatpickr, Dropzone, …):",
         "     <comment>php bin/console tailsfadmin:assets:install</comment>",
         "",
-        "  2. Importer le thème dans votre entrée Tailwind (assets/styles/app.css) :",
+        "  2. Import the theme into your Tailwind entrypoint (assets/styles/app.css):",
         "     <comment>@import \"tailwindcss\";</comment>",
         "     <comment>@import \"../../vendor/tailsfadmin/tailsfadmin-bundle/assets/styles/theme.css\";</comment>",
         "",
-        "  Puis compilez : <comment>php bin/console tailwind:build && php bin/console asset-map:compile</comment>",
+        "  Then compile: <comment>php bin/console tailwind:build && php bin/console asset-map:compile</comment>",
         "",
-        "  Le path AssetMapper des contrôleurs est déjà posé (config/packages/tailsfadmin_assets.yaml).",
-        "  Documentation : <comment>https://github.com/thibmonier/tailsfadmin#readme</comment>"
+        "  The controllers' AssetMapper path is already set (config/packages/tailsfadmin_assets.yaml).",
+        "  Documentation: <comment>https://github.com/thibmonier/tailsfadmin#readme</comment>"
     ]
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT

Recipe for [`tailsfadmin/tailsfadmin-bundle`](https://packagist.org/packages/tailsfadmin/tailsfadmin-bundle) — a reusable Symfony admin theme (Symfony UX / Stimulus / AssetMapper / Tailwind CSS v4), based on TailAdmin.

Published on Packagist (stable, latest `v1.4.2`).

The recipe:
- registers the bundle in `config/bundles.php`;
- adds a default `config/packages/tailsfadmin.yaml` (minimal menu + locales);
- adds `config/packages/tailsfadmin_assets.yaml` declaring the bundle's Stimulus controllers AssetMapper path (kept in a separate file so it merges with, rather than overwrites, the app's `asset_mapper.yaml`; inert when AssetMapper isn't used);
- prints a post-install message pointing to the two asset steps (`tailsfadmin:assets:install` for local vendoring — no CDN — and the Tailwind theme import).

Manifest is idempotent (`copy-from-recipe`, no overwrite without confirmation).

CI fixes applied: removed the unsupported `aliases` key, and reindented the menu YAML to 4-space multiples.