### PR TITLE
Add recipe for indexnowkit/symfony-bundle

### DIFF
--- a/indexnowkit/symfony-bundle/0.15/config/packages/indexnowkit.yaml
+++ b/indexnowkit/symfony-bundle/0.15/config/packages/indexnowkit.yaml
@@ -1,0 +1,3 @@
+indexnowkit:
+    key: '%env(INDEXNOW_KEY)%'
+    base_url: '%env(INDEXNOW_BASE_URL)%'

--- a/indexnowkit/symfony-bundle/0.15/config/routes/indexnowkit.yaml
+++ b/indexnowkit/symfony-bundle/0.15/config/routes/indexnowkit.yaml
@@ -1,0 +1,2 @@
+indexnowkit:
+    resource: '@IndexNowKitBundle/config/routes.php'

--- a/indexnowkit/symfony-bundle/0.15/manifest.json
+++ b/indexnowkit/symfony-bundle/0.15/manifest.json
@@ -1,0 +1,15 @@
+{
+    "bundles": {
+        "IndexNowKit\\SymfonyBundle\\IndexNowKitBundle": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "env": {
+        "#1": "The IndexNow key, served at /<key>.txt. Generate one into .env.local: bin/console indexnow:key:generate --write-env",
+        "#2": "Empty outside production = dry run (nothing is sent); empty in production = a configuration error indexnow:check explains",
+        "INDEXNOW_KEY": "",
+        "#3": "The public URL of the site (console commands and Messenger workers have no request to read it from)",
+        "INDEXNOW_BASE_URL": "https://www.example.com"
+    }
+}

--- a/indexnowkit/symfony-bundle/0.15/post-install.txt
+++ b/indexnowkit/symfony-bundle/0.15/post-install.txt
@@ -1,0 +1,9 @@
+  <fg=blue;options=bold>IndexNow</> is installed: search engines (Yandex, Bing, Naver, Seznam, ...) get told which pages changed.
+
+  <options=bold>Next steps:</>
+    1. Run <comment>bin/console indexnow:key:generate --write-env</> — writes <comment>INDEXNOW_KEY</> to <comment>.env.local</>
+    2. Set <comment>INDEXNOW_BASE_URL</> to the public URL of the site
+    3. Add <comment>#[IndexNow(route: '...')]</> to the entities that have a public page (needs <comment>indexnowkit/doctrine</>)
+    4. Run <comment>bin/console indexnow:check</> — it verifies the key file, the transport and the configuration
+
+  Documentation: https://github.com/indexnowkit/php/tree/main/packages/symfony-bundle


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/indexnowkit/symfony-bundle

Recipe for [indexnowkit/symfony-bundle](https://github.com/indexnowkit/php/tree/main/packages/symfony-bundle) (0.15): a bundle that tells search engines (Yandex, Bing, Naver, Seznam, ...) through [IndexNow](https://www.indexnow.org) which pages changed when a Doctrine entity is committed.

What the recipe does:

- registers `IndexNowKit\SymfonyBundle\IndexNowKitBundle` for all environments;
- `config/packages/indexnowkit.yaml` with the two values the bundle cannot guess: the key and the public base URL, both from env;
- `config/routes/indexnowkit.yaml` importing the bundle's key-file route (`/<key>.txt`, which the engines fetch to verify ownership);
- `.env`: `INDEXNOW_KEY` generated by Flex (the key is served publicly at `/<key>.txt`, it is not a secret; the protocol accepts 8–128 chars of `[A-Za-z0-9-]`, so a generated hex secret is a valid key) and `INDEXNOW_BASE_URL` as a placeholder.
