### PR TITLE
Add recipe for jpmmartin/sylius-nmi-plugin

### DIFF
--- a/jpmmartin/sylius-nmi-plugin/1.0/config/packages/jpm_martin_sylius_nmi.yaml
+++ b/jpmmartin/sylius-nmi-plugin/1.0/config/packages/jpm_martin_sylius_nmi.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: "@JpmMartinSyliusNmiPlugin/config/config.yaml" }

--- a/jpmmartin/sylius-nmi-plugin/1.0/config/routes/jpm_martin_sylius_nmi.yaml
+++ b/jpmmartin/sylius-nmi-plugin/1.0/config/routes/jpm_martin_sylius_nmi.yaml
@@ -1,0 +1,18 @@
+jpm_martin_sylius_nmi_shop:
+    resource: "@JpmMartinSyliusNmiPlugin/config/routes/shop.yaml"
+
+jpm_martin_sylius_nmi_admin:
+    resource: "@JpmMartinSyliusNmiPlugin/config/routes/admin.yaml"
+    prefix: /%sylius_admin.path_name%
+
+# Required if you want NMI to tell your store what it did. Without it there is no endpoint and
+# nothing arrives. No prefix: not the locale, not the admin path. See the README's "Webhooks".
+jpm_martin_sylius_nmi_webhook:
+    resource: "@JpmMartinSyliusNmiPlugin/config/routes/webhook.yaml"
+
+# Required if you turn saved cards on, and harmless if you do not. See the README's "Saved cards".
+jpm_martin_sylius_nmi_shop_account:
+    resource: "@JpmMartinSyliusNmiPlugin/config/routes/shop_account.yaml"
+    prefix: /{_locale}/account
+    requirements:
+        _locale: ^[A-Za-z]{2,4}(_([A-Za-z]{4}|[0-9]{3}))?(_([A-Za-z]{2}|[0-9]{3}))?$

--- a/jpmmartin/sylius-nmi-plugin/1.0/manifest.json
+++ b/jpmmartin/sylius-nmi-plugin/1.0/manifest.json
@@ -1,0 +1,20 @@
+{
+    "bundles": {
+        "JpmMartin\\SyliusNmiPlugin\\JpmMartinSyliusNmiPlugin": ["all"]
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
+    },
+    "add-lines": [
+        {
+            "file": "assets/shop/entrypoint.js",
+            "content": "import '@vendor/jpmmartin/sylius-nmi-plugin/assets/shop/entrypoint';",
+            "position": "bottom",
+            "warn_if_missing": true
+        }
+    ],
+    "gitignore": [
+        "/config/encryption/*.key",
+        "!/config/encryption/test.key"
+    ]
+}

--- a/jpmmartin/sylius-nmi-plugin/1.0/post-install.txt
+++ b/jpmmartin/sylius-nmi-plugin/1.0/post-install.txt
@@ -1,0 +1,14 @@
+  * <fg=blue>Four things no recipe can do, in this order:</>
+
+    <comment>yarn add @nmipayments/nmi-pay && yarn build</comment>   the browser component and the shop build
+    <comment>bin/console doctrine:migrations:migrate</comment>        the plugin's four tables
+
+  * <fg=blue>A key of your own, before the first payment method is saved.</> The skeleton's test.key is
+    published; point the store at a new path <comment>first</comment>, then generate — the generator writes
+    wherever the store points at that moment:
+
+    <comment>.env.local:</comment>  SYLIUS_PAYMENT_ENCRYPTION_KEY_PATH=%kernel.project_dir%/config/encryption/payment.key
+    <comment>bin/console sylius:payment:generate-key</comment>
+
+  * <fg=blue>Then</> Configuration → Payment methods → Create → NMI, and read <comment>Testing against the sandbox</comment>
+    before the first payment: https://github.com/jpmmartin/SyliusNmiPlugin#readme


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| License       | MIT
| Packagist     | https://packagist.org/packages/jpmmartin/sylius-nmi-plugin

Recipe for the NMI payment gateway plugin for Sylius 2.2 (`type: sylius-plugin`), version 1.0. It registers the bundle, copies the configuration import and the route imports, adds the plugin's script to the store's shop entrypoint through the `@vendor` alias a Sylius Standard store defines (the same line the `flux-se/sylius-stripe-plugin` recipe adds), adds the ignore rules for a generated encryption key, and prints what no recipe can do. On purpose it does not change the store's encryption key path: a store may already hold other plugins' credentials encrypted with the current key.

The recipe is kept in the plugin's repository under the same layout as this one, compiled with `symfony-tools/recipes-checker` and applied to a fresh Sylius Standard store in the plugin's own CI on every change, after the same `lint:manifests` and `lint:yaml` this repository runs: https://github.com/jpmmartin/SyliusNmiPlugin/blob/main/.github/workflows/install.yaml
